### PR TITLE
feat(models): add model catalog schema and loader

### DIFF
--- a/python/configs/models/catalog/dashscope.yaml
+++ b/python/configs/models/catalog/dashscope.yaml
@@ -1,0 +1,36 @@
+entries:
+  - ref: dashscope/qwen3-max
+    provider: dashscope
+    native_model_id: qwen3-max
+    display_name: Qwen3 Max
+    aliases:
+      - qwen3-max
+    status: stable
+    visibility: default
+    metadata:
+      family: qwen3
+      tier: flagship
+
+  - ref: dashscope/qwen3-plus
+    provider: dashscope
+    native_model_id: qwen3-plus
+    display_name: Qwen3 Plus
+    aliases:
+      - qwen3-plus
+    status: stable
+    visibility: default
+    metadata:
+      family: qwen3
+      tier: balanced
+
+  - ref: dashscope/qwen3-flash
+    provider: dashscope
+    native_model_id: qwen3-flash
+    display_name: Qwen3 Flash
+    aliases:
+      - qwen3-flash
+    status: stable
+    visibility: default
+    metadata:
+      family: qwen3
+      tier: fast

--- a/python/configs/models/catalog/deepseek.yaml
+++ b/python/configs/models/catalog/deepseek.yaml
@@ -1,0 +1,26 @@
+entries:
+  - ref: deepseek/deepseek-v3.1
+    provider: deepseek
+    native_model_id: deepseek-v3.1
+    display_name: DeepSeek V3.1
+    aliases:
+      - deepseek-v3.1
+      - deepseek-chat
+    status: stable
+    visibility: default
+    metadata:
+      family: deepseek-v3
+      tier: flagship
+
+  - ref: deepseek/deepseek-r1
+    provider: deepseek
+    native_model_id: deepseek-r1
+    display_name: DeepSeek R1
+    aliases:
+      - deepseek-r1
+      - deepseek-reasoner
+    status: stable
+    visibility: default
+    metadata:
+      family: deepseek-r1
+      tier: reasoning

--- a/python/configs/models/catalog/google.yaml
+++ b/python/configs/models/catalog/google.yaml
@@ -1,0 +1,26 @@
+entries:
+  - ref: google/gemini-2.5-pro
+    provider: google
+    native_model_id: gemini-2.5-pro
+    display_name: Gemini 2.5 Pro
+    aliases:
+      - gemini25-pro
+      - gemini-2.5-pro
+    status: stable
+    visibility: default
+    metadata:
+      family: gemini-2.5
+      tier: flagship
+
+  - ref: google/gemini-2.5-flash
+    provider: google
+    native_model_id: gemini-2.5-flash
+    display_name: Gemini 2.5 Flash
+    aliases:
+      - gemini25-flash
+      - gemini-2.5-flash
+    status: stable
+    visibility: default
+    metadata:
+      family: gemini-2.5
+      tier: fast

--- a/python/configs/models/catalog/openai.yaml
+++ b/python/configs/models/catalog/openai.yaml
@@ -1,0 +1,39 @@
+entries:
+  - ref: openai/gpt-5.4
+    provider: openai
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+    aliases:
+      - gpt54
+      - gpt-5.4
+    status: stable
+    visibility: default
+    metadata:
+      family: gpt-5
+      tier: flagship
+
+  - ref: openai/gpt-5.4-mini
+    provider: openai
+    native_model_id: gpt-5-mini-2025-08-07
+    display_name: GPT-5.4 Mini
+    aliases:
+      - gpt54-mini
+      - gpt-5.4-mini
+    status: stable
+    visibility: default
+    metadata:
+      family: gpt-5
+      tier: efficient
+
+  - ref: openai/gpt-4.1
+    provider: openai
+    native_model_id: gpt-4.1-2025-04-14
+    display_name: GPT-4.1
+    aliases:
+      - gpt41
+      - gpt-4.1
+    status: stable
+    visibility: default
+    metadata:
+      family: gpt-4.1
+      tier: flagship

--- a/python/configs/models/catalog/openrouter.yaml
+++ b/python/configs/models/catalog/openrouter.yaml
@@ -1,0 +1,37 @@
+entries:
+  - ref: openrouter/qwen3-max
+    provider: openrouter
+    native_model_id: qwen/qwen3-max
+    display_name: Qwen3 Max
+    aliases:
+      - qwen3-max
+    status: stable
+    visibility: default
+    metadata:
+      family: qwen3
+      tier: flagship
+
+  - ref: openrouter/claude-sonnet-4.5
+    provider: openrouter
+    native_model_id: anthropic/claude-sonnet-4.5
+    display_name: Claude Sonnet 4.5
+    aliases:
+      - claude-sonnet-45
+      - sonnet-4.5
+    status: stable
+    visibility: default
+    metadata:
+      family: claude-4.5
+      tier: flagship
+
+  - ref: openrouter/gemini-2.5-pro
+    provider: openrouter
+    native_model_id: google/gemini-2.5-pro
+    display_name: Gemini 2.5 Pro
+    aliases:
+      - gemini-2.5-pro
+    status: stable
+    visibility: default
+    metadata:
+      family: gemini-2.5
+      tier: flagship

--- a/python/configs/models/catalog/siliconflow.yaml
+++ b/python/configs/models/catalog/siliconflow.yaml
@@ -1,0 +1,25 @@
+entries:
+  - ref: siliconflow/deepseek-v3.1-terminus
+    provider: siliconflow
+    native_model_id: deepseek-ai/DeepSeek-V3.1-Terminus
+    display_name: DeepSeek V3.1 Terminus
+    aliases:
+      - deepseek-v3.1-terminus
+    status: stable
+    visibility: default
+    metadata:
+      family: deepseek-v3
+      tier: flagship
+
+  - ref: siliconflow/glm-4.5
+    provider: siliconflow
+    native_model_id: zai-org/GLM-4.5
+    display_name: GLM-4.5
+    aliases:
+      - glm45
+      - glm-4.5
+    status: stable
+    visibility: default
+    metadata:
+      family: glm-4.5
+      tier: flagship

--- a/python/valuecell/config/model_catalog.py
+++ b/python/valuecell/config/model_catalog.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from yaml import YAMLError
 
 from valuecell.config.constants import CONFIG_DIR
 
@@ -180,8 +181,13 @@ class ModelCatalogLoader:
         return ModelCatalog(entries=tuple(entries))
 
     def _load_yaml(self, path: Path) -> Any:
-        with open(path, "r", encoding="utf-8") as file:
-            return yaml.safe_load(file)
+        try:
+            with open(path, "r", encoding="utf-8") as file:
+                return yaml.safe_load(file)
+        except YAMLError as exc:
+            raise ValueError(
+                f"Malformed catalog file {path}: invalid YAML: {exc}"
+            ) from exc
 
     def _extract_entries(self, loaded_data: Any, path: Path) -> List[Any]:
         if loaded_data is None:
@@ -217,6 +223,8 @@ class ModelCatalogLoader:
         aliases_by_provider: Dict[str, Dict[str, str]] = {}
 
         for entry in entries:
+            self._validate_ref_provider_consistency(entry)
+
             previous_ref = seen_refs.get(entry.normalized_ref)
             if previous_ref is not None:
                 raise ValueError(
@@ -237,6 +245,21 @@ class ModelCatalogLoader:
                         f"conflicts with '{previous_alias}'"
                     )
                 provider_aliases[normalized_alias] = alias
+
+    def _validate_ref_provider_consistency(self, entry: ModelCatalogEntry) -> None:
+        if "/" not in entry.ref:
+            raise ValueError(
+                "Malformed catalog entry: ref must use 'provider/model' format: "
+                f"ref='{entry.ref}'"
+            )
+
+        ref_provider, _, _ = entry.ref.partition("/")
+        normalized_ref_provider = _normalize_key(ref_provider)
+        if normalized_ref_provider != entry.provider:
+            raise ValueError(
+                "Malformed catalog entry: ref/provider mismatch: "
+                f"ref='{entry.ref}', provider='{entry.provider}'"
+            )
 
 
 _catalog_loader: Optional[ModelCatalogLoader] = None

--- a/python/valuecell/config/model_catalog.py
+++ b/python/valuecell/config/model_catalog.py
@@ -1,0 +1,250 @@
+"""Model catalog schema and loader.
+
+This module provides:
+- pydantic schema validation for model catalog entries
+- normalized backend types for runtime-safe access
+- a loader that reads catalog YAML files from repo config path
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from valuecell.config.constants import CONFIG_DIR
+
+
+DEFAULT_MODEL_CATALOG_DIR = Path("models") / "catalog"
+
+
+def _normalize_key(value: str) -> str:
+    """Normalize keys used for matching and de-duplication."""
+    return value.strip().lower()
+
+
+class ModelCatalogEntrySchema(BaseModel):
+    """Single model catalog entry parsed from YAML."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ref: str = Field(..., description="Canonical catalog ref, e.g. openai/gpt-5.4")
+    provider: str = Field(..., description="Provider key, e.g. openai")
+    native_model_id: str = Field(..., description="Provider-native runtime model id")
+    display_name: str = Field(..., description="UI-facing display name")
+    aliases: List[str] = Field(default_factory=list)
+    status: Optional[str] = None
+    visibility: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator(
+        "ref", "provider", "native_model_id", "display_name", mode="before"
+    )
+    @classmethod
+    def _validate_required_non_empty(cls, value: Any) -> Any:
+        if not isinstance(value, str):
+            raise ValueError("must be a non-empty string")
+
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must be a non-empty string")
+
+        return stripped
+
+    @field_validator("aliases", mode="before")
+    @classmethod
+    def _validate_aliases(cls, value: Any) -> Any:
+        if value is None:
+            return []
+
+        if not isinstance(value, list):
+            raise ValueError("must be a list")
+
+        normalized_aliases: List[str] = []
+        for alias in value:
+            if not isinstance(alias, str):
+                raise ValueError("must contain only strings")
+
+            alias_value = alias.strip()
+            if not alias_value:
+                raise ValueError("must not contain empty strings")
+
+            normalized_aliases.append(alias_value)
+
+        return normalized_aliases
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _validate_metadata(cls, value: Any) -> Any:
+        if value is None:
+            return {}
+
+        if not isinstance(value, dict):
+            raise ValueError("must be an object")
+
+        return value
+
+
+@dataclass(frozen=True)
+class ModelCatalogEntry:
+    """Normalized backend representation of a catalog entry."""
+
+    ref: str
+    provider: str
+    native_model_id: str
+    display_name: str
+    aliases: tuple[str, ...]
+    status: Optional[str]
+    visibility: Optional[str]
+    metadata: Dict[str, Any]
+    normalized_ref: str
+    normalized_aliases: tuple[str, ...]
+
+    @classmethod
+    def from_schema(cls, schema: ModelCatalogEntrySchema) -> "ModelCatalogEntry":
+        normalized_provider = _normalize_key(schema.provider)
+
+        aliases = tuple(schema.aliases)
+        normalized_aliases = tuple(_normalize_key(alias) for alias in aliases)
+
+        return cls(
+            ref=schema.ref,
+            provider=normalized_provider,
+            native_model_id=schema.native_model_id,
+            display_name=schema.display_name,
+            aliases=aliases,
+            status=schema.status,
+            visibility=schema.visibility,
+            metadata=dict(schema.metadata),
+            normalized_ref=_normalize_key(schema.ref),
+            normalized_aliases=normalized_aliases,
+        )
+
+
+@dataclass(frozen=True)
+class ModelCatalog:
+    """Model catalog collection with helper indexes."""
+
+    entries: tuple[ModelCatalogEntry, ...]
+
+
+class ModelCatalogLoader:
+    """Load and validate model catalog config files from repository configs."""
+
+    def __init__(self, config_dir: Optional[Path] = None):
+        self.config_dir = Path(config_dir) if config_dir is not None else CONFIG_DIR
+
+    def load(
+        self, relative_catalog_dir: Path = DEFAULT_MODEL_CATALOG_DIR
+    ) -> ModelCatalog:
+        """Load and validate model catalog from YAML files.
+
+        Args:
+            relative_catalog_dir: relative path under config dir, default models/catalog
+
+        Returns:
+            Validated model catalog.
+        """
+        catalog_dir = self.config_dir / relative_catalog_dir
+        if not catalog_dir.exists():
+            return ModelCatalog(entries=())
+
+        if not catalog_dir.is_dir():
+            raise ValueError(f"Model catalog path is not a directory: {catalog_dir}")
+
+        yaml_files = sorted(catalog_dir.glob("*.yaml"))
+        entries: List[ModelCatalogEntry] = []
+
+        for path in yaml_files:
+            loaded_data = self._load_yaml(path)
+            raw_entries = self._extract_entries(loaded_data, path)
+
+            for index, raw_entry in enumerate(raw_entries):
+                if not isinstance(raw_entry, dict):
+                    raise ValueError(
+                        f"Malformed catalog entry in {path} at index {index}: "
+                        "each entry must be an object"
+                    )
+
+                try:
+                    schema = ModelCatalogEntrySchema.model_validate(raw_entry)
+                except ValidationError as exc:
+                    raise ValueError(
+                        f"Malformed catalog entry in {path} at index {index}: {exc}"
+                    ) from exc
+
+                entries.append(ModelCatalogEntry.from_schema(schema))
+
+        self._validate_duplicates(entries)
+        return ModelCatalog(entries=tuple(entries))
+
+    def _load_yaml(self, path: Path) -> Any:
+        with open(path, "r", encoding="utf-8") as file:
+            return yaml.safe_load(file)
+
+    def _extract_entries(self, loaded_data: Any, path: Path) -> List[Any]:
+        if loaded_data is None:
+            return []
+
+        if isinstance(loaded_data, list):
+            return loaded_data
+
+        if isinstance(loaded_data, dict):
+            entries = loaded_data.get("entries")
+            if entries is not None:
+                if not isinstance(entries, list):
+                    raise ValueError(
+                        f"Malformed catalog file {path}: 'entries' must be a list"
+                    )
+                return entries
+
+            models = loaded_data.get("models")
+            if models is not None:
+                if not isinstance(models, list):
+                    raise ValueError(
+                        f"Malformed catalog file {path}: 'models' must be a list"
+                    )
+                return models
+
+        raise ValueError(
+            f"Malformed catalog file {path}: "
+            "expected a list or object with 'entries'/'models'"
+        )
+
+    def _validate_duplicates(self, entries: List[ModelCatalogEntry]) -> None:
+        seen_refs: Dict[str, str] = {}
+        aliases_by_provider: Dict[str, Dict[str, str]] = {}
+
+        for entry in entries:
+            previous_ref = seen_refs.get(entry.normalized_ref)
+            if previous_ref is not None:
+                raise ValueError(
+                    "Duplicate model ref detected: "
+                    f"'{entry.ref}' conflicts with '{previous_ref}'"
+                )
+            seen_refs[entry.normalized_ref] = entry.ref
+
+            provider_aliases = aliases_by_provider.setdefault(entry.provider, {})
+            for alias, normalized_alias in zip(
+                entry.aliases, entry.normalized_aliases
+            ):
+                previous_alias = provider_aliases.get(normalized_alias)
+                if previous_alias is not None:
+                    raise ValueError(
+                        "Duplicate alias detected within provider scope: "
+                        f"provider='{entry.provider}', alias='{alias}' "
+                        f"conflicts with '{previous_alias}'"
+                    )
+                provider_aliases[normalized_alias] = alias
+
+
+_catalog_loader: Optional[ModelCatalogLoader] = None
+
+
+def get_model_catalog_loader() -> ModelCatalogLoader:
+    """Get singleton model catalog loader."""
+    global _catalog_loader
+    if _catalog_loader is None:
+        _catalog_loader = ModelCatalogLoader()
+    return _catalog_loader

--- a/python/valuecell/config/tests/test_model_catalog.py
+++ b/python/valuecell/config/tests/test_model_catalog.py
@@ -118,3 +118,42 @@ entries:
 
     with pytest.raises(ValueError, match="Malformed catalog entry"):
         loader.load()
+
+
+def test_load_model_catalog_ref_provider_mismatch_rejected(tmp_path: Path) -> None:
+    _write_catalog_file(
+        tmp_path,
+        "openai.yaml",
+        """
+entries:
+  - ref: openai/gpt-5.4
+    provider: deepseek
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+""",
+    )
+
+    loader = ModelCatalogLoader(config_dir=tmp_path)
+
+    with pytest.raises(ValueError, match="ref/provider mismatch"):
+        loader.load()
+
+
+def test_load_model_catalog_invalid_yaml_rejected(tmp_path: Path) -> None:
+    _write_catalog_file(
+        tmp_path,
+        "openai.yaml",
+        """
+entries:
+  - ref: openai/gpt-5.4
+    provider: openai
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+    aliases: [gpt54, gpt-5.4
+""",
+    )
+
+    loader = ModelCatalogLoader(config_dir=tmp_path)
+
+    with pytest.raises(ValueError, match="Malformed catalog file .*invalid YAML"):
+        loader.load()

--- a/python/valuecell/config/tests/test_model_catalog.py
+++ b/python/valuecell/config/tests/test_model_catalog.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+
+import pytest
+
+from valuecell.config.model_catalog import ModelCatalogLoader
+
+
+def _write_catalog_file(base_dir: Path, filename: str, content: str) -> None:
+    catalog_dir = base_dir / "models" / "catalog"
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    (catalog_dir / filename).write_text(content, encoding="utf-8")
+
+
+def test_load_model_catalog_valid(tmp_path: Path) -> None:
+    _write_catalog_file(
+        tmp_path,
+        "openai.yaml",
+        """
+entries:
+  - ref: OpenAI/GPT-5.4
+    provider: OpenAI
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+    aliases: [GPT54, gpt-5.4]
+    status: stable
+    visibility: public
+    metadata:
+      family: gpt-5
+""",
+    )
+
+    loader = ModelCatalogLoader(config_dir=tmp_path)
+    catalog = loader.load()
+
+    assert len(catalog.entries) == 1
+    entry = catalog.entries[0]
+    assert entry.ref == "OpenAI/GPT-5.4"
+    assert entry.provider == "openai"
+    assert entry.native_model_id == "gpt-5-2025-08-07"
+    assert entry.display_name == "GPT-5.4"
+    assert entry.aliases == ("GPT54", "gpt-5.4")
+    assert entry.normalized_ref == "openai/gpt-5.4"
+    assert entry.normalized_aliases == ("gpt54", "gpt-5.4")
+
+
+def test_load_model_catalog_duplicate_refs_rejected(tmp_path: Path) -> None:
+    _write_catalog_file(
+        tmp_path,
+        "provider_a.yaml",
+        """
+entries:
+  - ref: openai/gpt-5.4
+    provider: openai
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+""",
+    )
+    _write_catalog_file(
+        tmp_path,
+        "provider_b.yaml",
+        """
+entries:
+  - ref: OpenAI/GPT-5.4
+    provider: openai
+    native_model_id: gpt-5-2025-09-01
+    display_name: GPT-5.4 alt
+""",
+    )
+
+    loader = ModelCatalogLoader(config_dir=tmp_path)
+
+    with pytest.raises(ValueError, match="Duplicate model ref detected"):
+        loader.load()
+
+
+def test_load_model_catalog_duplicate_aliases_same_provider_rejected(
+    tmp_path: Path,
+) -> None:
+    _write_catalog_file(
+        tmp_path,
+        "openai.yaml",
+        """
+entries:
+  - ref: openai/gpt-5.4
+    provider: openai
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+    aliases: [gpt54]
+  - ref: openai/gpt-4.1
+    provider: openai
+    native_model_id: gpt-4.1-2025-04-14
+    display_name: GPT-4.1
+    aliases: [GPT54]
+""",
+    )
+
+    loader = ModelCatalogLoader(config_dir=tmp_path)
+
+    with pytest.raises(
+        ValueError, match="Duplicate alias detected within provider scope"
+    ):
+        loader.load()
+
+
+def test_load_model_catalog_malformed_entry_rejected(tmp_path: Path) -> None:
+    _write_catalog_file(
+        tmp_path,
+        "openai.yaml",
+        """
+entries:
+  - ref: openai/gpt-5.4
+    provider: openai
+    display_name: GPT-5.4
+""",
+    )
+
+    loader = ModelCatalogLoader(config_dir=tmp_path)
+
+    with pytest.raises(ValueError, match="Malformed catalog entry"):
+        loader.load()


### PR DESCRIPTION
## Summary
- add a first-class model catalog schema and isolated loader
- validate required fields plus duplicate refs and provider-scoped aliases
- add an initial curated catalog under `python/configs/models/catalog/`
- add focused unit tests for valid load and malformed/duplicate rejection paths

## Testing
- `cd python && uv run pytest -q valuecell/config/tests/test_model_catalog.py`
- `cd python && uv run python - <<'PY'
from valuecell.config.model_catalog import ModelCatalogLoader
catalog = ModelCatalogLoader().load()
print(len(catalog.entries))
PY`
