### PR TITLE
feat(models): add catalog resolver APIs

### DIFF
--- a/python/valuecell/config/model_resolver.py
+++ b/python/valuecell/config/model_resolver.py
@@ -101,13 +101,29 @@ class ModelResolver:
             provider_native_ids = self._entries_by_provider_native_id.setdefault(
                 entry.provider, {}
             )
-            provider_native_ids[_normalize_key(entry.native_model_id)] = entry
+            normalized_native_id = _normalize_key(entry.native_model_id)
+            existing_native_entry = provider_native_ids.get(normalized_native_id)
+            if existing_native_entry is not None:
+                raise ValueError(
+                    "Duplicate native_model_id detected within provider scope: "
+                    f"provider='{entry.provider}', native_model_id='{entry.native_model_id}' "
+                    f"conflicts with '{existing_native_entry.native_model_id}'"
+                )
+            provider_native_ids[normalized_native_id] = entry
 
             provider_legacy_ids = self._entries_by_provider_legacy_id.setdefault(
                 entry.provider, {}
             )
             for legacy_id in self._extract_legacy_ids(entry):
-                provider_legacy_ids[_normalize_key(legacy_id)] = entry
+                normalized_legacy_id = _normalize_key(legacy_id)
+                existing_legacy_entry = provider_legacy_ids.get(normalized_legacy_id)
+                if existing_legacy_entry is not None:
+                    raise ValueError(
+                        "Duplicate legacy_id detected within provider scope: "
+                        f"provider='{entry.provider}', legacy_id='{legacy_id}' "
+                        f"conflicts with '{existing_legacy_entry.ref}'"
+                    )
+                provider_legacy_ids[normalized_legacy_id] = entry
 
     def _extract_legacy_ids(self, entry: ModelCatalogEntry) -> tuple[str, ...]:
         raw = entry.metadata.get("legacy_ids")

--- a/python/valuecell/config/model_resolver.py
+++ b/python/valuecell/config/model_resolver.py
@@ -1,0 +1,219 @@
+"""Model catalog resolver utilities.
+
+This module resolves user-facing model identifiers into canonical model catalog entries.
+Resolution supports canonical refs, aliases, provider-native ids, and legacy ids.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Literal, Optional
+
+from valuecell.config.loader import ConfigLoader
+from valuecell.config.model_catalog import (
+    ModelCatalog,
+    ModelCatalogEntry,
+    ModelCatalogLoader,
+)
+
+
+MatchType = Literal["canonical_ref", "alias", "native_id", "legacy_id"]
+
+
+def _normalize_key(value: str) -> str:
+    return value.strip().lower()
+
+
+@dataclass(frozen=True)
+class ModelResolution:
+    """Resolved canonical model entry with match type."""
+
+    entry: ModelCatalogEntry
+    match_type: MatchType
+
+
+class ModelResolver:
+    """Resolve model identifiers against the model catalog and legacy provider ids."""
+
+    def __init__(
+        self,
+        catalog: ModelCatalog,
+        legacy_model_ids_by_provider: Optional[Dict[str, set[str]]] = None,
+    ) -> None:
+        self.catalog = catalog
+        self._legacy_model_ids_by_provider = legacy_model_ids_by_provider or {}
+
+        self._entries_by_ref: Dict[str, ModelCatalogEntry] = {}
+        self._entries_by_provider_alias: Dict[str, Dict[str, ModelCatalogEntry]] = {}
+        self._entries_by_provider_native_id: Dict[str, Dict[str, ModelCatalogEntry]] = {}
+        self._entries_by_provider_legacy_id: Dict[str, Dict[str, ModelCatalogEntry]] = {}
+
+        self._build_indexes(catalog.entries)
+
+    @classmethod
+    def from_config(cls, config_dir: Optional[Path] = None) -> "ModelResolver":
+        catalog_loader = ModelCatalogLoader(config_dir=config_dir)
+        catalog = catalog_loader.load()
+
+        legacy_ids = cls._load_legacy_provider_model_ids(config_dir=config_dir)
+        return cls(catalog=catalog, legacy_model_ids_by_provider=legacy_ids)
+
+    @staticmethod
+    def _load_legacy_provider_model_ids(
+        config_dir: Optional[Path] = None,
+    ) -> Dict[str, set[str]]:
+        loader = ConfigLoader(config_dir=config_dir)
+        ids_by_provider: Dict[str, set[str]] = {}
+
+        for provider in loader.list_providers():
+            provider_config = loader.load_provider_config(provider)
+            provider_ids: set[str] = set()
+
+            default_model = provider_config.get("default_model")
+            if isinstance(default_model, str) and default_model.strip():
+                provider_ids.add(_normalize_key(default_model))
+
+            models = provider_config.get("models", [])
+            if not isinstance(models, list):
+                ids_by_provider[_normalize_key(provider)] = provider_ids
+                continue
+
+            for model in models:
+                if not isinstance(model, dict):
+                    continue
+                model_id = model.get("id")
+                if isinstance(model_id, str) and model_id.strip():
+                    provider_ids.add(_normalize_key(model_id))
+
+            ids_by_provider[_normalize_key(provider)] = provider_ids
+
+        return ids_by_provider
+
+    def _build_indexes(self, entries: Iterable[ModelCatalogEntry]) -> None:
+        for entry in entries:
+            self._entries_by_ref[entry.normalized_ref] = entry
+
+            provider_aliases = self._entries_by_provider_alias.setdefault(
+                entry.provider, {}
+            )
+            for normalized_alias in entry.normalized_aliases:
+                provider_aliases[normalized_alias] = entry
+
+            provider_native_ids = self._entries_by_provider_native_id.setdefault(
+                entry.provider, {}
+            )
+            provider_native_ids[_normalize_key(entry.native_model_id)] = entry
+
+            provider_legacy_ids = self._entries_by_provider_legacy_id.setdefault(
+                entry.provider, {}
+            )
+            for legacy_id in self._extract_legacy_ids(entry):
+                provider_legacy_ids[_normalize_key(legacy_id)] = entry
+
+    def _extract_legacy_ids(self, entry: ModelCatalogEntry) -> tuple[str, ...]:
+        raw = entry.metadata.get("legacy_ids")
+        if not isinstance(raw, list):
+            return ()
+
+        legacy_ids: list[str] = []
+        for value in raw:
+            if not isinstance(value, str):
+                continue
+            normalized = value.strip()
+            if normalized:
+                legacy_ids.append(normalized)
+        return tuple(legacy_ids)
+
+    def resolve(
+        self,
+        identifier: str,
+        provider: Optional[str] = None,
+    ) -> Optional[ModelResolution]:
+        if not isinstance(identifier, str):
+            return None
+
+        normalized_identifier = _normalize_key(identifier)
+        if not normalized_identifier:
+            return None
+
+        normalized_provider = _normalize_key(provider) if provider else None
+
+        ref_match = self._entries_by_ref.get(normalized_identifier)
+        if ref_match is not None:
+            if (
+                normalized_provider is not None
+                and ref_match.provider != normalized_provider
+            ):
+                return None
+            return ModelResolution(entry=ref_match, match_type="canonical_ref")
+
+        alias_match = self._resolve_provider_scoped_match(
+            index=self._entries_by_provider_alias,
+            identifier=normalized_identifier,
+            provider=normalized_provider,
+        )
+        if alias_match is not None:
+            return ModelResolution(entry=alias_match, match_type="alias")
+
+        native_match = self._resolve_provider_scoped_match(
+            index=self._entries_by_provider_native_id,
+            identifier=normalized_identifier,
+            provider=normalized_provider,
+        )
+        if native_match is not None:
+            return ModelResolution(entry=native_match, match_type="native_id")
+
+        legacy_match = self._resolve_legacy_match(
+            identifier=normalized_identifier,
+            provider=normalized_provider,
+        )
+        if legacy_match is not None:
+            return ModelResolution(entry=legacy_match, match_type="legacy_id")
+
+        return None
+
+    def _resolve_provider_scoped_match(
+        self,
+        index: Dict[str, Dict[str, ModelCatalogEntry]],
+        identifier: str,
+        provider: Optional[str],
+    ) -> Optional[ModelCatalogEntry]:
+        if provider is not None:
+            return index.get(provider, {}).get(identifier)
+
+        matches: list[ModelCatalogEntry] = []
+        for provider_index in index.values():
+            entry = provider_index.get(identifier)
+            if entry is not None:
+                matches.append(entry)
+
+        if len(matches) == 1:
+            return matches[0]
+
+        return None
+
+    def _resolve_legacy_match(
+        self,
+        identifier: str,
+        provider: Optional[str],
+    ) -> Optional[ModelCatalogEntry]:
+        providers: tuple[str, ...]
+        if provider is not None:
+            providers = (provider,)
+        else:
+            providers = tuple(self._legacy_model_ids_by_provider.keys())
+
+        matches: list[ModelCatalogEntry] = []
+        for provider_name in providers:
+            legacy_ids = self._legacy_model_ids_by_provider.get(provider_name, set())
+            if identifier not in legacy_ids:
+                continue
+
+            legacy_index = self._entries_by_provider_legacy_id.get(provider_name, {})
+            matched_entry = legacy_index.get(identifier)
+            if matched_entry is not None:
+                matches.append(matched_entry)
+
+        if len(matches) == 1:
+            return matches[0]
+
+        return None

--- a/python/valuecell/config/tests/test_model_resolver.py
+++ b/python/valuecell/config/tests/test_model_resolver.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from valuecell.config.model_resolver import ModelResolver
 
 
@@ -86,3 +88,77 @@ def test_resolve_legacy_id_from_provider_compatibility(tmp_path: Path) -> None:
     assert resolved is not None
     assert resolved.entry.ref == "openai/gpt-5.4"
     assert resolved.match_type == "legacy_id"
+
+
+
+def test_duplicate_native_model_id_same_provider_rejected(tmp_path: Path) -> None:
+    _write_catalog_file(
+        tmp_path,
+        "openai.yaml",
+        """
+entries:
+  - ref: openai/gpt-5.4
+    provider: openai
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+  - ref: openai/gpt-5.4-alt
+    provider: openai
+    native_model_id: GPT-5-2025-08-07
+    display_name: GPT-5.4 Alt
+""",
+    )
+    _write_provider_file(
+        tmp_path,
+        "openai",
+        """
+default_model: gpt-5
+models:
+  - id: gpt-5
+    name: GPT-5 Legacy
+""",
+    )
+
+    with pytest.raises(
+        ValueError, match="Duplicate native_model_id detected within provider scope"
+    ):
+        ModelResolver.from_config(config_dir=tmp_path)
+
+
+
+def test_duplicate_legacy_id_same_provider_rejected(tmp_path: Path) -> None:
+    _write_catalog_file(
+        tmp_path,
+        "openai.yaml",
+        """
+entries:
+  - ref: openai/gpt-5.4
+    provider: openai
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+    metadata:
+      legacy_ids:
+        - gpt-5
+  - ref: openai/gpt-4.1
+    provider: openai
+    native_model_id: gpt-4.1-2025-04-14
+    display_name: GPT-4.1
+    metadata:
+      legacy_ids:
+        - GPT-5
+""",
+    )
+    _write_provider_file(
+        tmp_path,
+        "openai",
+        """
+default_model: gpt-5
+models:
+  - id: gpt-5
+    name: GPT-5 Legacy
+""",
+    )
+
+    with pytest.raises(
+        ValueError, match="Duplicate legacy_id detected within provider scope"
+    ):
+        ModelResolver.from_config(config_dir=tmp_path)

--- a/python/valuecell/config/tests/test_model_resolver.py
+++ b/python/valuecell/config/tests/test_model_resolver.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+from valuecell.config.model_resolver import ModelResolver
+
+
+def _write_catalog_file(base_dir: Path, filename: str, content: str) -> None:
+    catalog_dir = base_dir / "models" / "catalog"
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    (catalog_dir / filename).write_text(content, encoding="utf-8")
+
+
+def _write_provider_file(base_dir: Path, provider: str, content: str) -> None:
+    providers_dir = base_dir / "providers"
+    providers_dir.mkdir(parents=True, exist_ok=True)
+    (providers_dir / f"{provider}.yaml").write_text(content, encoding="utf-8")
+
+
+def _prepare_config(tmp_path: Path) -> None:
+    _write_catalog_file(
+        tmp_path,
+        "openai.yaml",
+        """
+entries:
+  - ref: openai/gpt-5.4
+    provider: openai
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+    aliases:
+      - gpt54
+    metadata:
+      legacy_ids:
+        - gpt-5
+""",
+    )
+    _write_provider_file(
+        tmp_path,
+        "openai",
+        """
+default_model: gpt-5
+models:
+  - id: gpt-5
+    name: GPT-5 Legacy
+""",
+    )
+
+
+def test_resolve_canonical_ref(tmp_path: Path) -> None:
+    _prepare_config(tmp_path)
+    resolver = ModelResolver.from_config(config_dir=tmp_path)
+
+    resolved = resolver.resolve("OpenAI/GPT-5.4")
+
+    assert resolved is not None
+    assert resolved.entry.ref == "openai/gpt-5.4"
+    assert resolved.match_type == "canonical_ref"
+
+
+def test_resolve_alias(tmp_path: Path) -> None:
+    _prepare_config(tmp_path)
+    resolver = ModelResolver.from_config(config_dir=tmp_path)
+
+    resolved = resolver.resolve("gpt54")
+
+    assert resolved is not None
+    assert resolved.entry.ref == "openai/gpt-5.4"
+    assert resolved.match_type == "alias"
+
+
+def test_resolve_native_id(tmp_path: Path) -> None:
+    _prepare_config(tmp_path)
+    resolver = ModelResolver.from_config(config_dir=tmp_path)
+
+    resolved = resolver.resolve("gpt-5-2025-08-07")
+
+    assert resolved is not None
+    assert resolved.entry.ref == "openai/gpt-5.4"
+    assert resolved.match_type == "native_id"
+
+
+def test_resolve_legacy_id_from_provider_compatibility(tmp_path: Path) -> None:
+    _prepare_config(tmp_path)
+    resolver = ModelResolver.from_config(config_dir=tmp_path)
+
+    resolved = resolver.resolve("gpt-5")
+
+    assert resolved is not None
+    assert resolved.entry.ref == "openai/gpt-5.4"
+    assert resolved.match_type == "legacy_id"

--- a/python/valuecell/server/api/routers/models.py
+++ b/python/valuecell/server/api/routers/models.py
@@ -10,6 +10,8 @@ from fastapi import APIRouter, HTTPException, Query
 from valuecell.config.constants import CONFIG_DIR
 from valuecell.config.loader import get_config_loader
 from valuecell.config.manager import get_config_manager
+from valuecell.config.model_catalog import ModelCatalogEntry
+from valuecell.config.model_resolver import ModelResolver
 from valuecell.utils.env import get_system_env_path
 
 from ..schemas import SuccessResponse
@@ -17,11 +19,14 @@ from ..schemas.model import (
     AddModelRequest,
     CheckModelRequest,
     CheckModelResponse,
+    CatalogModelItem,
     ModelItem,
     ModelProviderSummary,
     ProviderDetailData,
     ProviderModelEntry,
     ProviderUpdateRequest,
+    ResolveModelRequest,
+    ResolveModelResponse,
     SetDefaultModelRequest,
     SetDefaultProviderRequest,
 )
@@ -35,6 +40,12 @@ try:
 except Exception:  # pragma: no cover - constants may not exist in minimal env
     DEFAULT_MODEL_PROVIDER = "openrouter"
     DEFAULT_AGENT_MODEL = "gpt-4o"
+
+
+def get_model_resolver(config_dir: Path | None = None) -> ModelResolver:
+    """Create a model resolver backed by the configured catalog and provider YAMLs."""
+    resolved_config_dir = CONFIG_DIR if config_dir is None else config_dir
+    return ModelResolver.from_config(config_dir=resolved_config_dir)
 
 
 def create_models_router() -> APIRouter:
@@ -137,6 +148,144 @@ def create_models_router() -> APIRouter:
             "ollama": None,
         }
         return mapping.get(provider)
+
+    def _to_catalog_item(entry: ModelCatalogEntry) -> CatalogModelItem:
+        return CatalogModelItem(
+            canonical_ref=entry.ref,
+            provider=entry.provider,
+            native_model_id=entry.native_model_id,
+            display_name=entry.display_name,
+            status=entry.status,
+            visibility=entry.visibility,
+        )
+
+    def _contains_query(entry, query: str) -> bool:
+        lowered_query = query.lower()
+        if lowered_query in entry.ref.lower():
+            return True
+        if lowered_query in entry.provider.lower():
+            return True
+        if lowered_query in entry.native_model_id.lower():
+            return True
+        if lowered_query in entry.display_name.lower():
+            return True
+
+        for alias in entry.aliases:
+            if lowered_query in alias.lower():
+                return True
+        return False
+
+    @router.get(
+        "/catalog",
+        response_model=SuccessResponse[List[CatalogModelItem]],
+        summary="List model catalog entries",
+        description=(
+            "List canonical model catalog entries. "
+            "Supports optional filtering by provider, status, visibility, and query."
+        ),
+    )
+    async def list_model_catalog(
+        provider: str | None = Query(
+            default=None, description="Filter by provider (case-insensitive)"
+        ),
+        status: str | None = Query(
+            default=None, description="Filter by catalog status (case-insensitive)"
+        ),
+        visibility: str | None = Query(
+            default=None, description="Filter by catalog visibility (case-insensitive)"
+        ),
+        query: str | None = Query(
+            default=None,
+            description=(
+                "Filter by free-text query across ref, provider, native model id, "
+                "display name, and aliases"
+            ),
+        ),
+    ) -> SuccessResponse[List[CatalogModelItem]]:
+        try:
+            resolver = get_model_resolver()
+            entries = list(resolver.catalog.entries)
+
+            normalized_provider = provider.strip().lower() if provider else None
+            normalized_status = status.strip().lower() if status else None
+            normalized_visibility = visibility.strip().lower() if visibility else None
+            normalized_query = query.strip().lower() if query else None
+
+            if normalized_provider:
+                entries = [
+                    entry
+                    for entry in entries
+                    if entry.provider.lower() == normalized_provider
+                ]
+            if normalized_status:
+                entries = [
+                    entry
+                    for entry in entries
+                    if (entry.status or "").strip().lower() == normalized_status
+                ]
+            if normalized_visibility:
+                entries = [
+                    entry
+                    for entry in entries
+                    if (entry.visibility or "").strip().lower() == normalized_visibility
+                ]
+            if normalized_query:
+                entries = [
+                    entry
+                    for entry in entries
+                    if _contains_query(entry=entry, query=normalized_query)
+                ]
+
+            data = [_to_catalog_item(entry) for entry in entries]
+            return SuccessResponse.create(data=data, msg=f"Retrieved {len(data)} models")
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to list model catalog: {e}"
+            )
+
+    @router.post(
+        "/resolve",
+        response_model=SuccessResponse[ResolveModelResponse],
+        summary="Resolve model identifier",
+        description=(
+            "Resolve canonical refs, aliases, native model ids, or legacy ids "
+            "into a canonical catalog model entry."
+        ),
+    )
+    async def resolve_model(
+        payload: ResolveModelRequest,
+    ) -> SuccessResponse[ResolveModelResponse]:
+        try:
+            resolver = get_model_resolver()
+            resolution = resolver.resolve(
+                identifier=payload.model, provider=payload.provider
+            )
+
+            if resolution is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        f"Model '{payload.model}' could not be resolved"
+                        if payload.provider is None
+                        else (
+                            f"Model '{payload.model}' could not be resolved "
+                            f"for provider '{payload.provider}'"
+                        )
+                    ),
+                )
+
+            data = ResolveModelResponse(
+                canonical_ref=resolution.entry.ref,
+                provider=resolution.entry.provider,
+                native_model_id=resolution.entry.native_model_id,
+                display_name=resolution.entry.display_name,
+                match_type=resolution.match_type,
+            )
+            return SuccessResponse.create(data=data, msg="Model resolved")
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to resolve model: {e}")
 
     @router.get(
         "/providers",

--- a/python/valuecell/server/api/schemas/model.py
+++ b/python/valuecell/server/api/schemas/model.py
@@ -1,6 +1,6 @@
 """Model-related API schemas."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -112,3 +112,29 @@ class CheckModelResponse(BaseModel):
         description="Status label like 'valid_config', 'reachable', 'timeout', 'request_failed'",
     )
     error: Optional[str] = Field(None, description="Error message if any")
+
+
+class CatalogModelItem(BaseModel):
+    canonical_ref: str = Field(..., description="Canonical catalog ref")
+    provider: str = Field(..., description="Model provider")
+    native_model_id: str = Field(..., description="Provider-native model id")
+    display_name: str = Field(..., description="Display name")
+    status: Optional[str] = Field(None, description="Catalog status")
+    visibility: Optional[str] = Field(None, description="Catalog visibility")
+
+
+class ResolveModelRequest(BaseModel):
+    model: str = Field(..., description="Model identifier to resolve")
+    provider: Optional[str] = Field(
+        None, description="Optional provider hint to narrow resolution"
+    )
+
+
+class ResolveModelResponse(BaseModel):
+    canonical_ref: str = Field(..., description="Canonical catalog ref")
+    provider: str = Field(..., description="Resolved provider")
+    native_model_id: str = Field(..., description="Resolved provider-native model id")
+    display_name: str = Field(..., description="Resolved display name")
+    match_type: Literal["canonical_ref", "alias", "native_id", "legacy_id"] = Field(
+        ..., description="How the resolver matched the input"
+    )

--- a/python/valuecell/server/api/tests/test_models_catalog_api.py
+++ b/python/valuecell/server/api/tests/test_models_catalog_api.py
@@ -1,0 +1,148 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from valuecell.config.model_resolver import ModelResolver
+from valuecell.server.api.routers import models as models_router
+
+
+def _write_catalog_file(base_dir: Path, filename: str, content: str) -> None:
+    catalog_dir = base_dir / "models" / "catalog"
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    (catalog_dir / filename).write_text(content, encoding="utf-8")
+
+
+def _write_provider_file(base_dir: Path, provider: str, content: str) -> None:
+    providers_dir = base_dir / "providers"
+    providers_dir.mkdir(parents=True, exist_ok=True)
+    (providers_dir / f"{provider}.yaml").write_text(content, encoding="utf-8")
+
+
+def _prepare_config(tmp_path: Path) -> None:
+    _write_catalog_file(
+        tmp_path,
+        "openai.yaml",
+        """
+entries:
+  - ref: openai/gpt-5.4
+    provider: openai
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+    aliases:
+      - gpt54
+    status: stable
+    visibility: default
+    metadata:
+      legacy_ids:
+        - gpt-5
+""",
+    )
+    _write_catalog_file(
+        tmp_path,
+        "google.yaml",
+        """
+entries:
+  - ref: google/gemini-2.5-flash
+    provider: google
+    native_model_id: gemini-2.5-flash
+    display_name: Gemini 2.5 Flash
+    aliases:
+      - gemini25-flash
+    status: stable
+    visibility: hidden
+""",
+    )
+
+    _write_provider_file(
+        tmp_path,
+        "openai",
+        """
+default_model: gpt-5
+models:
+  - id: gpt-5
+    name: GPT-5 Legacy
+""",
+    )
+    _write_provider_file(
+        tmp_path,
+        "google",
+        """
+default_model: gemini-2.5-flash
+models:
+  - id: gemini-2.5-flash
+    name: Gemini 2.5 Flash
+""",
+    )
+
+
+def _build_client(tmp_path: Path, monkeypatch) -> TestClient:
+    resolver = ModelResolver.from_config(config_dir=tmp_path)
+    monkeypatch.setattr(models_router, "get_model_resolver", lambda config_dir=None: resolver)
+
+    app = FastAPI()
+    app.include_router(models_router.create_models_router(), prefix="/api/v1")
+    return TestClient(app)
+
+
+def test_get_models_catalog_with_filters(tmp_path: Path, monkeypatch) -> None:
+    _prepare_config(tmp_path)
+    client = _build_client(tmp_path, monkeypatch)
+
+    response = client.get(
+        "/api/v1/models/catalog",
+        params={"provider": "openai", "status": "stable", "query": "gpt"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["code"] == 0
+    assert len(payload["data"]) == 1
+    assert payload["data"][0]["canonical_ref"] == "openai/gpt-5.4"
+
+
+def test_resolve_alias_via_api(tmp_path: Path, monkeypatch) -> None:
+    _prepare_config(tmp_path)
+    client = _build_client(tmp_path, monkeypatch)
+
+    response = client.post("/api/v1/models/resolve", json={"model": "gpt54"})
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["canonical_ref"] == "openai/gpt-5.4"
+    assert data["match_type"] == "alias"
+
+
+def test_resolve_native_id_via_api(tmp_path: Path, monkeypatch) -> None:
+    _prepare_config(tmp_path)
+    client = _build_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/api/v1/models/resolve", json={"model": "gpt-5-2025-08-07"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["canonical_ref"] == "openai/gpt-5.4"
+    assert data["match_type"] == "native_id"
+
+
+def test_resolve_legacy_id_via_api(tmp_path: Path, monkeypatch) -> None:
+    _prepare_config(tmp_path)
+    client = _build_client(tmp_path, monkeypatch)
+
+    response = client.post("/api/v1/models/resolve", json={"model": "gpt-5"})
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["canonical_ref"] == "openai/gpt-5.4"
+    assert data["match_type"] == "legacy_id"
+
+
+def test_resolve_model_not_found(tmp_path: Path, monkeypatch) -> None:
+    _prepare_config(tmp_path)
+    client = _build_client(tmp_path, monkeypatch)
+
+    response = client.post("/api/v1/models/resolve", json={"model": "unknown-model"})
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add a catalog-backed model resolver for canonical refs, aliases, provider-native ids, and legacy provider ids
- add read-only `GET /models/catalog` with provider/status/visibility/query filtering
- add `POST /models/resolve` returning canonical ref, provider, native model id, display name, and match type
- add focused resolver and API tests without changing runtime model execution behavior

## Testing
- `cd python && uv run pytest -q valuecell/config/tests valuecell/server/api/tests`
