### PR TITLE
feat(frontend): consume model catalog in picker

### DIFF
--- a/frontend/src/api/setting.ts
+++ b/frontend/src/api/setting.ts
@@ -8,6 +8,7 @@ import { API_QUERY_KEYS } from "@/constants/api";
 import type { ApiResponse } from "@/lib/api-client";
 import { apiClient } from "@/lib/api-client";
 import type {
+  CatalogModelItem,
   CheckModelRequest,
   CheckModelResult,
   MemoryItem,
@@ -57,6 +58,18 @@ export const useGetModelProviderDetail = (provider: string | undefined) => {
     queryFn: () =>
       apiClient.get<ApiResponse<ProviderDetail>>(
         `/models/providers/${provider}`,
+      ),
+    select: (data) => data.data,
+  });
+};
+
+export const useGetModelCatalog = (provider: string | undefined) => {
+  return useQuery({
+    enabled: !!provider,
+    queryKey: API_QUERY_KEYS.SETTING.modelCatalog(provider ? [provider] : []),
+    queryFn: () =>
+      apiClient.get<ApiResponse<CatalogModelItem[]>>(
+        `/models/catalog?provider=${encodeURIComponent(provider ?? "")}`,
       ),
     select: (data) => data.data,
   });

--- a/frontend/src/app/setting/components/models/model-detail.tsx
+++ b/frontend/src/app/setting/components/models/model-detail.tsx
@@ -1,13 +1,14 @@
 import { DialogDescription } from "@radix-ui/react-dialog";
 import { useForm } from "@tanstack/react-form";
 import { Eye, EyeOff, Plus, Trash2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 import {
   useAddProviderModel,
   useCheckModelAvailability,
   useDeleteProviderModel,
+  useGetModelCatalog,
   useGetModelProviderDetail,
   useSetDefaultProvider,
   useSetDefaultProviderModel,
@@ -57,6 +58,8 @@ export function ModelDetail({ provider }: ModelDetailProps) {
 
   const { data: providerDetail, isLoading: detailLoading } =
     useGetModelProviderDetail(provider);
+  const { data: modelCatalog = [], isLoading: catalogLoading } =
+    useGetModelCatalog(provider);
   const { mutate: updateConfig, isPending: updatingConfig } =
     useUpdateProviderConfig();
   const { mutate: addModel, isPending: addingModel } = useAddProviderModel();
@@ -146,7 +149,25 @@ export function ModelDetail({ provider }: ModelDetailProps) {
     settingDefaultProvider ||
     checkingAvailability;
 
-  if (detailLoading) {
+  const providerModels = useMemo(() => {
+    if (!providerDetail) return [];
+
+    const catalogByNativeId = new Map(
+      modelCatalog.map((entry) => [entry.native_model_id, entry]),
+    );
+
+    return providerDetail.models.map((model) => {
+      const catalogEntry = catalogByNativeId.get(model.model_id);
+      return {
+        ...model,
+        model_name:
+          catalogEntry?.display_name || model.model_name || model.model_id,
+        catalogStatus: catalogEntry?.status,
+      };
+    });
+  }, [modelCatalog, providerDetail]);
+
+  if (detailLoading || catalogLoading) {
     return (
       <div className="text-muted-foreground text-sm">
         {t("settings.models.loading")}
@@ -274,7 +295,6 @@ export function ModelDetail({ provider }: ModelDetailProps) {
               )}
             </configForm.Field>
 
-            {/* API Host section */}
             <configForm.Field name="base_url">
               {(field) => (
                 <Field className="text-foreground">
@@ -299,7 +319,6 @@ export function ModelDetail({ provider }: ModelDetailProps) {
             </configForm.Field>
           </FieldGroup>
 
-          {/* Models section */}
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
               <div className="font-medium text-base text-foreground">
@@ -396,35 +415,42 @@ export function ModelDetail({ provider }: ModelDetailProps) {
               </Dialog>
             </div>
 
-            {providerDetail.models.length === 0 ? (
+            {providerModels.length === 0 ? (
               <div className="rounded-lg border border-border border-dashed p-4 text-muted-foreground text-sm">
                 {t("settings.models.noModels")}
               </div>
             ) : (
               <div className="flex flex-col gap-2 rounded-lg border border-border bg-card p-3">
-                {providerDetail.models.map((m) => (
+                {providerModels.map((model) => (
                   <div
-                    key={m.model_id}
+                    key={model.model_id}
                     className="flex items-center justify-between"
                   >
-                    <span className="font-normal text-foreground text-sm">
-                      {m.model_name}
-                    </span>
+                    <div className="flex min-w-0 flex-col">
+                      <span className="font-normal text-foreground text-sm">
+                        {model.model_name}
+                      </span>
+                      {model.catalogStatus && model.catalogStatus !== "stable" ? (
+                        <span className="text-muted-foreground text-xs uppercase">
+                          {model.catalogStatus}
+                        </span>
+                      ) : null}
+                    </div>
 
                     <div className="flex items-center gap-3">
                       <Switch
                         className="cursor-pointer"
-                        checked={m.model_id === providerDetail.default_model_id}
+                        checked={model.model_id === providerDetail.default_model_id}
                         disabled={isBusy}
                         onCheckedChange={() =>
-                          handleSetDefaultModel(m.model_id)
+                          handleSetDefaultModel(model.model_id)
                         }
                       />
                       <Button
                         variant="ghost"
                         size="icon"
                         disabled={isBusy}
-                        onClick={() => handleDeleteModel(m.model_id)}
+                        onClick={() => handleDeleteModel(model.model_id)}
                       >
                         <Trash2 className="size-5" />
                       </Button>

--- a/frontend/src/components/valuecell/form/ai-model-form.tsx
+++ b/frontend/src/components/valuecell/form/ai-model-form.tsx
@@ -2,6 +2,7 @@ import { useStore } from "@tanstack/react-form";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  useGetModelCatalog,
   useGetModelProviderDetail,
   useGetSortedModelProviders,
 } from "@/api/setting";
@@ -32,17 +33,23 @@ export const AIModelForm = withForm({
       data: modelProviderDetail,
       refetch: fetchModelProviderDetail,
     } = useGetModelProviderDetail(provider);
+    const {
+      isLoading: isLoadingModelCatalog,
+      data: modelCatalog = [],
+    } = useGetModelCatalog(provider);
 
-    // Set the default provider once loaded and provider is not yet selected
     useEffect(() => {
       if (isLoadingProviders || !defaultProvider) return;
-      // Only set if provider field is empty (not yet selected by user)
       if (!provider) {
         form.setFieldValue("provider", defaultProvider);
       }
-    }, [isLoadingProviders, defaultProvider, provider]);
+    }, [isLoadingProviders, defaultProvider, provider, form]);
 
-    if (isLoadingProviders || isLoadingModelProviderDetail) {
+    if (
+      isLoadingProviders ||
+      isLoadingModelProviderDetail ||
+      isLoadingModelCatalog
+    ) {
       return <div>Loading...</div>;
     }
 
@@ -86,13 +93,34 @@ export const AIModelForm = withForm({
 
         <form.AppField name="model_id">
           {(field) => {
-            const models = modelProviderDetail?.models || [];
+            const catalogByNativeId = new Map(
+              modelCatalog.map((entry) => [entry.native_model_id, entry]),
+            );
+            const models = (modelProviderDetail?.models || []).map((model) => {
+              const catalogEntry = catalogByNativeId.get(model.model_id);
+              return {
+                model_id: model.model_id,
+                model_name:
+                  catalogEntry?.display_name || model.model_name || model.model_id,
+                metaLabel:
+                  catalogEntry?.status && catalogEntry.status !== "stable"
+                    ? catalogEntry.status
+                    : catalogEntry?.provider || provider,
+              };
+            });
 
             return (
               <field.SelectField label={t("strategy.form.aiModels.model")}>
-                {models.map((m) => (
-                  <SelectItem key={m.model_id} value={m.model_id}>
-                    {m.model_name}
+                {models.map((model) => (
+                  <SelectItem key={model.model_id} value={model.model_id}>
+                    <div className="flex w-full items-center justify-between gap-3">
+                      <span>{model.model_name}</span>
+                      {model.metaLabel ? (
+                        <span className="text-muted-foreground text-xs uppercase">
+                          {model.metaLabel}
+                        </span>
+                      ) : null}
+                    </div>
                   </SelectItem>
                 ))}
               </field.SelectField>

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -31,6 +31,7 @@ export const SETTING_QUERY_KEYS = {
   memoryList: ["memory"],
   modelProviders: ["model", "providers"],
   modelProviderDetail: queryKeyFn(["model", "detail"]),
+  modelCatalog: queryKeyFn(["model", "catalog"]),
 } as const;
 
 const STRATEGY_QUERY_KEYS = {

--- a/frontend/src/types/setting.ts
+++ b/frontend/src/types/setting.ts
@@ -21,6 +21,15 @@ export type ProviderDetail = {
   models: ProviderModelInfo[];
 };
 
+export type CatalogModelItem = {
+  canonical_ref: string;
+  provider: string;
+  native_model_id: string;
+  display_name: string;
+  status?: string;
+  visibility?: string;
+};
+
 // --- Model availability check ---
 export type CheckModelRequest = {
   provider?: string;


### PR DESCRIPTION
## Summary
- add a frontend catalog query hook for `/models/catalog`
- render catalog `display_name` values in the strategy model picker while keeping submission on existing `model_id`
- mirror the same curated naming/status display in provider model settings

## Validation
- cd frontend && bun run typecheck
- cd frontend && bun run lint

## Notes
- runtime behavior stays unchanged in this PR
- this keeps issue #3 scoped to the frontend read path only

Closes #3
