### PR TITLE
feat(runtime): resolve canonical model refs

### DIFF
--- a/python/valuecell/adapters/models/factory.py
+++ b/python/valuecell/adapters/models/factory.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 from loguru import logger
 
 from valuecell.config.manager import ConfigManager, ProviderConfig, get_config_manager
+from valuecell.config.model_resolver import ModelResolver
 
 
 class ModelProvider(ABC):
@@ -619,6 +620,71 @@ class ModelFactory:
             config_manager: ConfigManager instance (auto-created if None)
         """
         self.config_manager = config_manager or get_config_manager()
+        self._model_resolver: Optional[ModelResolver] = None
+
+    @staticmethod
+    def _clean_string(value: Optional[str]) -> Optional[str]:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+    def _get_model_resolver(self) -> ModelResolver:
+        if self._model_resolver is None:
+            self._model_resolver = ModelResolver.from_config(
+                config_dir=self.config_manager.loader.config_dir
+            )
+        return self._model_resolver
+
+    def _resolve_model_id_for_provider(
+        self,
+        provider: str,
+        model_id: Optional[str],
+        model_ref: Optional[str],
+    ) -> str:
+        provider_config = self.config_manager.get_provider_config(provider)
+        if not provider_config:
+            raise ValueError(f"Provider configuration not found: {provider}")
+
+        explicit_model_ref = self._clean_string(model_ref)
+        explicit_model_id = self._clean_string(model_id)
+
+        if explicit_model_ref:
+            resolution = self._get_model_resolver().resolve(
+                explicit_model_ref, provider=provider
+            )
+            if resolution is None:
+                raise ValueError(
+                    f"Model ref '{explicit_model_ref}' not found for provider '{provider}'"
+                )
+            return resolution.entry.native_model_id
+
+        if explicit_model_id:
+            return explicit_model_id
+
+        default_model_ref = self._clean_string(provider_config.default_model_ref)
+        if default_model_ref:
+            resolution = self._get_model_resolver().resolve(
+                default_model_ref, provider=provider
+            )
+            if resolution is not None:
+                return resolution.entry.native_model_id
+            logger.warning(
+                "Provider default_model_ref '{}' for provider '{}' cannot be resolved; "
+                "falling back to default_model",
+                default_model_ref,
+                provider,
+            )
+
+        fallback_model_id = self._clean_string(provider_config.default_model)
+        if fallback_model_id:
+            return fallback_model_id
+
+        raise ValueError(
+            f"No model could be resolved for provider '{provider}'. "
+            "Expected one of: explicit model_ref, explicit model_id, "
+            "provider default_model_ref, provider default_model."
+        )
 
     def register_provider(self, name: str, provider_class: type[ModelProvider]):
         """
@@ -637,6 +703,7 @@ class ModelFactory:
         provider: Optional[str] = None,
         use_fallback: bool = True,
         provider_models: Optional[dict] = None,
+        model_ref: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -679,7 +746,12 @@ class ModelFactory:
 
         # Try primary provider
         try:
-            return self._create_model_internal(model_id, provider, **kwargs)
+            resolved_model_id = self._resolve_model_id_for_provider(
+                provider=provider,
+                model_id=model_id,
+                model_ref=model_ref,
+            )
+            return self._create_model_internal(resolved_model_id, provider, **kwargs)
         except Exception as e:
             logger.warning(f"Failed to create model with provider {provider}: {e}")
 
@@ -713,8 +785,13 @@ class ModelFactory:
                             )
 
                     logger.info(f"Trying fallback provider: {fallback_provider}")
+                    resolved_model_id = self._resolve_model_id_for_provider(
+                        provider=fallback_provider,
+                        model_id=fallback_model_id,
+                        model_ref=None,
+                    )
                     return self._create_model_internal(
-                        fallback_model_id, fallback_provider, **kwargs
+                        resolved_model_id, fallback_provider, **kwargs
                     )
                 except Exception as fallback_error:
                     logger.warning(
@@ -759,6 +836,7 @@ class ModelFactory:
                 api_key=override_api_key,
                 base_url=provider_config.base_url,
                 default_model=provider_config.default_model,
+                default_model_ref=provider_config.default_model_ref,
                 models=provider_config.models,
                 parameters=provider_config.parameters,
                 default_embedding_model=provider_config.default_embedding_model,
@@ -832,12 +910,15 @@ class ModelFactory:
 
         logger.info(
             f"Creating model for agent '{agent_name}': "
-            f"model_id={model_config.model_id}, provider={model_config.provider}"
+            f"model_id={model_config.model_id}, "
+            f"model_ref={model_config.model_ref}, "
+            f"provider={model_config.provider}"
         )
 
         # Check if specified provider is available (has API key)
         provider = model_config.provider
         model_id = model_config.model_id
+        model_ref = model_config.model_ref
         is_valid, error_msg = self.config_manager.validate_provider(provider)
 
         if not is_valid:
@@ -853,6 +934,7 @@ class ModelFactory:
             # Priority: provider_models[fallback_provider] > provider's default_model
             if fallback_provider in model_config.provider_models:
                 model_id = model_config.provider_models[fallback_provider]
+                model_ref = None
                 logger.info(
                     f"Using provider-specific model for fallback: {fallback_provider} -> {model_id}"
                 )
@@ -863,6 +945,7 @@ class ModelFactory:
                 )
                 if provider_config:
                     model_id = provider_config.default_model
+                    model_ref = None
                     logger.info(
                         f"Using default model for fallback provider '{fallback_provider}': {model_id}"
                     )
@@ -873,6 +956,7 @@ class ModelFactory:
             provider=provider,
             use_fallback=use_fallback,
             provider_models=model_config.provider_models,
+            model_ref=model_ref,
             **merged_params,
         )
 
@@ -1161,6 +1245,7 @@ class ModelFactory:
                 api_key=override_api_key,
                 base_url=provider_config.base_url,
                 default_model=provider_config.default_model,
+                default_model_ref=provider_config.default_model_ref,
                 models=provider_config.models,
                 parameters=provider_config.parameters,
                 default_embedding_model=provider_config.default_embedding_model,
@@ -1213,7 +1298,10 @@ def get_model_factory() -> ModelFactory:
 
 
 def create_model(
-    model_id: Optional[str] = None, provider: Optional[str] = None, **kwargs
+    model_id: Optional[str] = None,
+    provider: Optional[str] = None,
+    model_ref: Optional[str] = None,
+    **kwargs,
 ):
     """
     Convenience function to create a model instance
@@ -1240,7 +1328,12 @@ def create_model(
         >>> model = create_model(temperature=0.9, max_tokens=8192)
     """
     factory = get_model_factory()
-    return factory.create_model(model_id, provider, **kwargs)
+    return factory.create_model(
+        model_id=model_id,
+        provider=provider,
+        model_ref=model_ref,
+        **kwargs,
+    )
 
 
 def create_model_for_agent(agent_name: str, **kwargs):

--- a/python/valuecell/adapters/models/tests/test_model_ref_resolution.py
+++ b/python/valuecell/adapters/models/tests/test_model_ref_resolution.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+from valuecell.adapters.models.factory import ModelFactory
+from valuecell.config.loader import ConfigLoader
+from valuecell.config.manager import ConfigManager
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _prepare_config(tmp_path: Path) -> ConfigManager:
+    _write(
+        tmp_path / "config.yaml",
+        """
+models:
+  primary_provider: openai
+""",
+    )
+    _write(
+        tmp_path / "providers" / "openai.yaml",
+        """
+enabled: true
+connection:
+  api_key_env: OPENAI_API_KEY
+default_model_ref: openai/gpt-5.4
+default_model: gpt-5
+models:
+  - id: gpt-5
+    name: GPT-5 Legacy
+defaults: {}
+""",
+    )
+    _write(
+        tmp_path / "models" / "catalog" / "openai.yaml",
+        """
+entries:
+  - ref: openai/gpt-5.4
+    provider: openai
+    native_model_id: gpt-5-2025-08-07
+    display_name: GPT-5.4
+    metadata:
+      legacy_ids:
+        - gpt-5
+""",
+    )
+    loader = ConfigLoader(config_dir=tmp_path)
+    return ConfigManager(loader=loader)
+
+
+def test_create_model_prefers_explicit_model_ref(
+    tmp_path: Path, monkeypatch
+) -> None:
+    manager = _prepare_config(tmp_path)
+    factory = ModelFactory(config_manager=manager)
+    monkeypatch.setattr(
+        factory,
+        "_create_model_internal",
+        lambda model_id, provider, **kwargs: {
+            "provider": provider,
+            "model_id": model_id,
+        },
+    )
+
+    result = factory.create_model(
+        provider="openai",
+        model_ref="openai/gpt-5.4",
+        model_id="gpt-5",
+        use_fallback=False,
+    )
+
+    assert result["provider"] == "openai"
+    assert result["model_id"] == "gpt-5-2025-08-07"
+
+
+def test_create_model_keeps_legacy_explicit_model_id(
+    tmp_path: Path, monkeypatch
+) -> None:
+    manager = _prepare_config(tmp_path)
+    factory = ModelFactory(config_manager=manager)
+    monkeypatch.setattr(
+        factory,
+        "_create_model_internal",
+        lambda model_id, provider, **kwargs: {
+            "provider": provider,
+            "model_id": model_id,
+        },
+    )
+
+    result = factory.create_model(
+        provider="openai",
+        model_id="gpt-5",
+        use_fallback=False,
+    )
+
+    assert result["provider"] == "openai"
+    assert result["model_id"] == "gpt-5"
+
+
+def test_create_model_uses_provider_default_model_ref(
+    tmp_path: Path, monkeypatch
+) -> None:
+    manager = _prepare_config(tmp_path)
+    factory = ModelFactory(config_manager=manager)
+    monkeypatch.setattr(
+        factory,
+        "_create_model_internal",
+        lambda model_id, provider, **kwargs: {
+            "provider": provider,
+            "model_id": model_id,
+        },
+    )
+
+    result = factory.create_model(
+        provider="openai",
+        use_fallback=False,
+    )
+
+    assert result["provider"] == "openai"
+    assert result["model_id"] == "gpt-5-2025-08-07"

--- a/python/valuecell/agents/common/trading/decision/grid_composer/llm_param_advisor.py
+++ b/python/valuecell/agents/common/trading/decision/grid_composer/llm_param_advisor.py
@@ -41,6 +41,7 @@ class GridParamAdvisor:
             model = model_utils.create_model_with_provider(
                 provider=cfg.provider,
                 model_id=cfg.model_id,
+                model_ref=cfg.model_ref,
                 api_key=cfg.api_key,
             )
 

--- a/python/valuecell/agents/common/trading/decision/prompt_based/composer.py
+++ b/python/valuecell/agents/common/trading/decision/prompt_based/composer.py
@@ -59,6 +59,7 @@ class LlmComposer(BaseComposer):
         self._model = model_utils.create_model_with_provider(
             provider=cfg.provider,
             model_id=cfg.model_id,
+            model_ref=cfg.model_ref,
             api_key=cfg.api_key,
         )
         self.agent = AgnoAgent(

--- a/python/valuecell/agents/common/trading/models.py
+++ b/python/valuecell/agents/common/trading/models.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from valuecell.utils.ts import get_current_timestamp_ms
 
 from .constants import (
-    DEFAULT_AGENT_MODEL,
     DEFAULT_CAP_FACTOR,
     DEFAULT_INITIAL_CAPITAL,
     DEFAULT_MAX_LEVERAGE,
@@ -80,9 +79,13 @@ class LLMModelConfig(BaseModel):
         default=DEFAULT_MODEL_PROVIDER,
         description="Model provider (e.g., 'openrouter', 'google', 'openai')",
     )
-    model_id: str = Field(
-        default=DEFAULT_AGENT_MODEL,
+    model_id: Optional[str] = Field(
+        default=None,
         description="Model identifier (e.g., 'deepseek-ai/deepseek-v3.1', 'gpt-4o')",
+    )
+    model_ref: Optional[str] = Field(
+        default=None,
+        description="Canonical model ref (e.g., 'openai/gpt-5.4')",
     )
     api_key: str = Field(..., description="API key for the model provider")
 
@@ -107,12 +110,6 @@ class LLMModelConfig(BaseModel):
                 values.setdefault(
                     "provider", values.get("provider") or provider_cfg.name
                 )
-                values.setdefault(
-                    "model_id",
-                    values.get("model_id")
-                    or provider_cfg.default_model
-                    or DEFAULT_AGENT_MODEL,
-                )
                 # If api_key not provided by client, use provider config api_key
                 if values.get("api_key") is None and getattr(
                     provider_cfg, "api_key", None
@@ -120,15 +117,11 @@ class LLMModelConfig(BaseModel):
                     values["api_key"] = provider_cfg.api_key
             else:
                 values.setdefault("provider", resolved_provider)
-                values.setdefault(
-                    "model_id", values.get("model_id") or DEFAULT_AGENT_MODEL
-                )
         except Exception:
             # Fall back to constants if config manager unavailable
             values.setdefault(
                 "provider", values.get("provider") or DEFAULT_MODEL_PROVIDER
             )
-            values.setdefault("model_id", values.get("model_id") or DEFAULT_AGENT_MODEL)
 
         return values
 

--- a/python/valuecell/config/manager.py
+++ b/python/valuecell/config/manager.py
@@ -29,6 +29,7 @@ class ProviderConfig:
     default_model: str
     models: List[Dict[str, Any]]
     parameters: Dict[str, Any]
+    default_model_ref: Optional[str] = None
     # Embedding support
     default_embedding_model: Optional[str] = None
     embedding_models: List[Dict[str, Any]] = None
@@ -50,6 +51,7 @@ class AgentModelConfig:
     """Agent model configuration with provider-specific model mappings"""
 
     model_id: str
+    model_ref: Optional[str]
     provider: str
     parameters: Dict[str, Any]
     # Provider-specific model mappings for fallback
@@ -225,6 +227,7 @@ class ConfigManager:
 
         # Get default model
         default_model = provider_data.get("default_model", "")
+        default_model_ref = provider_data.get("default_model_ref")
 
         # Get model list
         models = provider_data.get("models", [])
@@ -247,6 +250,7 @@ class ConfigManager:
             api_key=api_key,
             base_url=base_url,
             default_model=default_model,
+            default_model_ref=default_model_ref,
             models=models,
             parameters=defaults,
             default_embedding_model=default_embedding_model,
@@ -295,13 +299,8 @@ class ConfigManager:
 
         # Get model ID (with fallback chain)
         model_id = primary.get("model_id")
+        model_ref = primary.get("model_ref")
         provider = primary.get("provider") or self.primary_provider
-
-        # If model_id is None, use provider's default
-        if not model_id:
-            provider_config = self.get_provider_config(provider)
-            if provider_config:
-                model_id = provider_config.default_model
 
         # Get parameters
         parameters = primary.get("parameters") or {}
@@ -316,6 +315,7 @@ class ConfigManager:
 
         primary_model = AgentModelConfig(
             model_id=model_id or "",
+            model_ref=model_ref,
             provider=provider,
             parameters=merged_params,
             provider_models=provider_models,
@@ -328,6 +328,7 @@ class ConfigManager:
             embedding_provider_models = embedding_data.get("provider_models", {})
             embedding_model = AgentModelConfig(
                 model_id=embedding_data.get("model_id", ""),
+                model_ref=embedding_data.get("model_ref"),
                 provider=embedding_data.get("provider", "openai"),
                 parameters=embedding_data.get("parameters", {}),
                 provider_models=embedding_provider_models,

--- a/python/valuecell/server/api/routers/strategy_agent.py
+++ b/python/valuecell/server/api/routers/strategy_agent.py
@@ -93,9 +93,8 @@ def create_strategy_agent_router() -> APIRouter:
             # If same provider + model_id comes with a new api_key, override previous key
             try:
                 provider = user_request.llm_model_config.provider
-                model_id = user_request.llm_model_config.model_id
                 new_api_key = user_request.llm_model_config.api_key
-                if provider and model_id and new_api_key:
+                if provider and new_api_key:
                     loader = get_config_loader()
                     provider_cfg_raw = loader.load_provider_config(provider) or {}
                     api_key_env = provider_cfg_raw.get("connection", {}).get(
@@ -196,6 +195,7 @@ def create_strategy_agent_router() -> APIRouter:
                                 "strategy_type": strategy_type_enum,
                                 "model_provider": request.llm_model_config.provider,
                                 "model_id": request.llm_model_config.model_id,
+                                "model_ref": request.llm_model_config.model_ref,
                                 "exchange_id": request.exchange_config.exchange_id,
                                 "trading_mode": request.exchange_config.trading_mode.value,
                             }

--- a/python/valuecell/utils/model.py
+++ b/python/valuecell/utils/model.py
@@ -240,6 +240,7 @@ def get_model_for_agent(agent_name: str, **kwargs):
 def create_model_with_provider(
     provider: str,
     model_id: Optional[str] = None,
+    model_ref: Optional[str] = None,
     api_key: Optional[str] = None,
     **kwargs,
 ):
@@ -277,54 +278,18 @@ def create_model_with_provider(
         return create_model(
             model_id=model_id,
             provider=provider,
+            model_ref=model_ref,
             use_fallback=False,  # Don't fallback when explicitly requesting a provider
             **kwargs,
         )
-
-    # Minimal override: instantiate the provider class with a copy of its
-    # ProviderConfig but using the provided api_key. This avoids changing the
-    # global configuration and keeps the change localized to this call.
-    try:
-        from valuecell.adapters.models.factory import get_model_factory
-        from valuecell.config.manager import ProviderConfig, get_config_manager
-    except Exception:
-        # Fallback to factory convenience if imports fail for some reason
-        return create_model(
-            model_id=model_id,
-            provider=provider,
-            use_fallback=False,
-            api_key=api_key,
-            **kwargs,
-        )
-
-    cfg_mgr = get_config_manager()
-    existing = cfg_mgr.get_provider_config(provider)
-    if not existing:
-        raise ValueError(f"Provider configuration not found: {provider}")
-
-    # Build a shallow copy of ProviderConfig overriding api_key
-    overridden = ProviderConfig(
-        name=existing.name,
-        enabled=existing.enabled,
+    return create_model(
+        model_id=model_id,
+        provider=provider,
+        model_ref=model_ref,
+        use_fallback=False,
         api_key=api_key,
-        base_url=existing.base_url,
-        default_model=existing.default_model,
-        models=existing.models,
-        parameters=existing.parameters,
-        default_embedding_model=existing.default_embedding_model,
-        embedding_models=existing.embedding_models,
-        embedding_parameters=existing.embedding_parameters,
-        extra_config=existing.extra_config,
+        **kwargs,
     )
-
-    factory = get_model_factory()
-    provider_class = factory._providers.get(provider)
-    if not provider_class:
-        raise ValueError(f"Unsupported provider: {provider}")
-
-    provider_instance = provider_class(overridden)
-    # Delegate to the provider instance directly so the supplied api_key is used
-    return provider_instance.create_model(model_id, **kwargs)
 
 
 # ============================================


### PR DESCRIPTION
## Summary
- add runtime support for canonical `model_ref` resolution before adapter creation
- prefer `model_ref` over explicit `model_id`, then fall back to provider `default_model_ref`, then legacy `default_model`
- thread `model_ref` through runtime model config and strategy agent request handling
- add focused tests covering dual-read runtime behavior

## Validation
- python/.venv/bin/python -m pytest python/valuecell/adapters/models/tests/test_model_ref_resolution.py python/valuecell/config/tests/test_model_resolver.py python/valuecell/server/api/tests/test_models_catalog_api.py

## Notes
- keeps legacy `model_id` configs working unchanged
- does not include frontend work or provider scan/import changes

Closes #4
