### PR TITLE
feat(models): add provider scan import workflow

### DIFF
--- a/python/valuecell/adapters/models/provider_inventory.py
+++ b/python/valuecell/adapters/models/provider_inventory.py
@@ -1,0 +1,76 @@
+"""Provider-facing model inventory source for scan workflow.
+
+This module is intentionally decoupled from curated provider YAML model lists.
+It provides a minimal adapter boundary so scan can later switch to real provider APIs
+without changing router logic.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Protocol, Sequence
+
+
+@dataclass(frozen=True)
+class ProviderInventoryModel:
+    """Single model candidate discovered from a provider-facing inventory source."""
+
+    model_id: str
+    model_name: str | None = None
+
+
+class ProviderInventorySource(Protocol):
+    """Abstraction for fetching provider model inventories."""
+
+    async def list_models(self, provider: str) -> list[ProviderInventoryModel]:
+        """Return provider-facing model inventory candidates for the given provider."""
+
+
+_STUB_PROVIDER_INVENTORY: Dict[str, Sequence[ProviderInventoryModel]] = {
+    # Provider-specific stub values for local development and tests.
+    "openai": (
+        ProviderInventoryModel(model_id="gpt-5-2025-08-07", model_name="GPT-5.4"),
+        ProviderInventoryModel(
+            model_id="gpt-5-mini-2025-08-07", model_name="GPT-5.4 Mini"
+        ),
+    ),
+    "google": (
+        ProviderInventoryModel(
+            model_id="gemini-2.5-flash", model_name="Gemini 2.5 Flash"
+        ),
+    ),
+    "openrouter": (
+        ProviderInventoryModel(model_id="openai/gpt-5", model_name="GPT-5"),
+        ProviderInventoryModel(
+            model_id="google/gemini-2.5-flash", model_name="Gemini 2.5 Flash"
+        ),
+    ),
+}
+
+
+class StubProviderInventorySource:
+    """Provider inventory source backed by static provider-specific stubs."""
+
+    def __init__(
+        self, inventory: Dict[str, Sequence[ProviderInventoryModel]] | None = None
+    ) -> None:
+        self._inventory = _STUB_PROVIDER_INVENTORY if inventory is None else inventory
+
+    async def list_models(self, provider: str) -> list[ProviderInventoryModel]:
+        models = self._inventory.get(provider, ())
+        return [
+            ProviderInventoryModel(model_id=item.model_id, model_name=item.model_name)
+            for item in models
+        ]
+
+
+_provider_inventory_source: ProviderInventorySource | None = None
+
+
+def get_provider_inventory_source() -> ProviderInventorySource:
+    """Return the active provider inventory source.
+
+    Defaults to a provider-specific stub source until live provider API adapters are added.
+    """
+    global _provider_inventory_source
+    if _provider_inventory_source is None:
+        _provider_inventory_source = StubProviderInventorySource()
+    return _provider_inventory_source

--- a/python/valuecell/server/api/routers/models.py
+++ b/python/valuecell/server/api/routers/models.py
@@ -1,8 +1,10 @@
 """Models API router: provide LLM model configuration defaults."""
 
 import os
+import re
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 
 import yaml
 from fastapi import APIRouter, HTTPException, Query
@@ -17,6 +19,11 @@ from valuecell.utils.env import get_system_env_path
 from ..schemas import SuccessResponse
 from ..schemas.model import (
     AddModelRequest,
+    CatalogImportItem,
+    CatalogImportRequest,
+    CatalogImportResponse,
+    ScanCandidateItem,
+    ScanDiffReport,
     CheckModelRequest,
     CheckModelResponse,
     CatalogModelItem,
@@ -28,6 +35,7 @@ from ..schemas.model import (
     ProviderUpdateRequest,
     ResolveModelRequest,
     ResolveModelResponse,
+    ProviderScanResponse,
     SetDefaultModelRequest,
     SetDefaultProviderRequest,
 )
@@ -96,6 +104,12 @@ def create_models_router() -> APIRouter:
     def _provider_yaml(provider: str) -> Path:
         return CONFIG_DIR / "providers" / f"{provider}.yaml"
 
+    def _scan_yaml(provider: str) -> Path:
+        return CONFIG_DIR / "models" / "scans" / f"{provider}.yaml"
+
+    def _imported_catalog_yaml(provider: str) -> Path:
+        return CONFIG_DIR / "models" / "catalog" / f"{provider}.imported.yaml"
+
     def _load_yaml(path: Path) -> dict:
         if not path.exists():
             return {}
@@ -105,6 +119,10 @@ def create_models_router() -> APIRouter:
     def _write_yaml(path: Path, data: dict) -> None:
         with open(path, "w", encoding="utf-8") as f:
             yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True)
+
+    def _write_yaml_with_parents(path: Path, data: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _write_yaml(path, data)
 
     def _refresh_configs() -> None:
         loader = get_config_loader()
@@ -175,6 +193,125 @@ def create_models_router() -> APIRouter:
             if lowered_query in alias.lower():
                 return True
         return False
+
+    def _to_scan_candidates(provider: str) -> List[dict[str, str | None]]:
+        manager = get_config_manager()
+        cfg = manager.get_provider_config(provider)
+        if cfg is None:
+            raise HTTPException(
+                status_code=404, detail=f"Provider '{provider}' not found"
+            )
+
+        candidates: List[dict[str, str | None]] = []
+        for model in cfg.models or []:
+            if not isinstance(model, dict):
+                continue
+            model_id = str(model.get("id", "")).strip()
+            if not model_id:
+                continue
+            model_name_raw = model.get("name")
+            model_name = None
+            if isinstance(model_name_raw, str):
+                normalized_name = model_name_raw.strip()
+                model_name = normalized_name if normalized_name else None
+            candidates.append({"model_id": model_id, "model_name": model_name})
+
+        return candidates
+
+    def _build_scan_response(
+        provider: str, scanned_at: str, candidates: List[dict[str, str | None]]
+    ) -> ProviderScanResponse:
+        resolver = get_model_resolver()
+        provider_entries = [
+            entry for entry in resolver.catalog.entries if entry.provider == provider
+        ]
+
+        by_native_id = {entry.native_model_id: entry for entry in provider_entries}
+        scan_ids = {candidate["model_id"] for candidate in candidates}
+        catalog_ids = {entry.native_model_id for entry in provider_entries}
+
+        new_model_ids = sorted(scan_ids - catalog_ids)
+        missing_model_ids = sorted(catalog_ids - scan_ids)
+        renamed_model_ids: List[str] = []
+        deprecated_model_ids: List[str] = []
+        response_candidates: List[ScanCandidateItem] = []
+
+        for candidate in candidates:
+            model_id = candidate["model_id"] or ""
+            model_name = candidate.get("model_name")
+            matched = by_native_id.get(model_id)
+            catalog_ref = matched.ref if matched is not None else None
+            catalog_status = matched.status if matched is not None else None
+            if matched is not None and catalog_status:
+                lowered_status = catalog_status.strip().lower()
+                if lowered_status in {"deprecated", "retired", "sunset"}:
+                    deprecated_model_ids.append(model_id)
+            if (
+                matched is not None
+                and isinstance(model_name, str)
+                and model_name.strip()
+                and model_name.strip() != matched.display_name
+            ):
+                renamed_model_ids.append(model_id)
+
+            response_candidates.append(
+                ScanCandidateItem(
+                    model_id=model_id,
+                    model_name=model_name,
+                    catalog_ref=catalog_ref,
+                    catalog_status=catalog_status,
+                )
+            )
+
+        return ProviderScanResponse(
+            provider=provider,
+            scanned_at=scanned_at,
+            candidates=response_candidates,
+            report=ScanDiffReport(
+                new_model_ids=new_model_ids,
+                missing_model_ids=missing_model_ids,
+                renamed_model_ids=sorted(set(renamed_model_ids)),
+                deprecated_model_ids=sorted(set(deprecated_model_ids)),
+            ),
+        )
+
+    def _slugify_ref_suffix(native_model_id: str) -> str:
+        lowered = native_model_id.strip().lower().replace("/", "-")
+        compacted = re.sub(r"[^a-z0-9._-]+", "-", lowered)
+        compacted = re.sub(r"-{2,}", "-", compacted).strip("-")
+        return compacted or "model"
+
+    def _next_available_ref(
+        provider: str, native_model_id: str, used_refs: set[str]
+    ) -> str:
+        base_ref = f"{provider}/{_slugify_ref_suffix(native_model_id)}"
+        if base_ref.lower() not in used_refs:
+            return base_ref
+
+        index = 2
+        while True:
+            candidate_ref = f"{base_ref}-{index}"
+            if candidate_ref.lower() not in used_refs:
+                return candidate_ref
+            index += 1
+
+    def _load_imported_catalog_entries(path: Path) -> List[Dict[str, Any]]:
+        loaded = _load_yaml(path)
+        if not loaded:
+            return []
+
+        if isinstance(loaded, dict):
+            entries = loaded.get("entries")
+            if isinstance(entries, list):
+                valid_entries = [entry for entry in entries if isinstance(entry, dict)]
+                return [dict(entry) for entry in valid_entries]
+            return []
+
+        if isinstance(loaded, list):
+            valid_entries = [entry for entry in loaded if isinstance(entry, dict)]
+            return [dict(entry) for entry in valid_entries]
+
+        return []
 
     @router.get(
         "/catalog",
@@ -356,6 +493,208 @@ def create_models_router() -> APIRouter:
             raise
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to get provider: {e}")
+
+    @router.post(
+        "/providers/{provider}/scan",
+        response_model=SuccessResponse[ProviderScanResponse],
+        summary="Scan provider models into scan state",
+        description=(
+            "Collect provider model candidates and persist them as scan results. "
+            "Scan results are not auto-imported into the official catalog."
+        ),
+    )
+    async def scan_provider_models(
+        provider: str,
+    ) -> SuccessResponse[ProviderScanResponse]:
+        try:
+            scanned_at = datetime.now(timezone.utc).isoformat()
+            candidates = _to_scan_candidates(provider=provider)
+            data = _build_scan_response(
+                provider=provider, scanned_at=scanned_at, candidates=candidates
+            )
+
+            scan_path = _scan_yaml(provider)
+            scan_doc = {
+                "provider": data.provider,
+                "scanned_at": data.scanned_at,
+                "candidates": [
+                    {
+                        "model_id": candidate.model_id,
+                        "model_name": candidate.model_name,
+                        "catalog_ref": candidate.catalog_ref,
+                        "catalog_status": candidate.catalog_status,
+                    }
+                    for candidate in data.candidates
+                ],
+                "report": {
+                    "new_model_ids": data.report.new_model_ids,
+                    "missing_model_ids": data.report.missing_model_ids,
+                    "renamed_model_ids": data.report.renamed_model_ids,
+                    "deprecated_model_ids": data.report.deprecated_model_ids,
+                },
+            }
+            _write_yaml_with_parents(scan_path, scan_doc)
+            return SuccessResponse.create(
+                data=data, msg=f"Scanned {len(data.candidates)} provider models"
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to scan provider '{provider}': {e}"
+            )
+
+    @router.post(
+        "/catalog/import",
+        response_model=SuccessResponse[CatalogImportResponse],
+        summary="Import selected scan candidates into catalog",
+        description=(
+            "Promote selected scan candidates into an imported catalog file. "
+            "Only explicitly selected candidates are imported."
+        ),
+    )
+    async def import_catalog_entries(
+        payload: CatalogImportRequest,
+    ) -> SuccessResponse[CatalogImportResponse]:
+        try:
+            provider = payload.provider.strip().lower()
+            if not provider:
+                raise HTTPException(status_code=400, detail="Provider is required")
+
+            selected_model_ids = {
+                model_id.strip() for model_id in payload.model_ids if model_id.strip()
+            }
+            if not selected_model_ids:
+                raise HTTPException(
+                    status_code=400, detail="At least one model_id must be provided"
+                )
+
+            # Ensure provider exists.
+            _to_scan_candidates(provider=provider)
+
+            scan_doc = _load_yaml(_scan_yaml(provider))
+            if not isinstance(scan_doc, dict):
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        "No scan state found for provider. "
+                        "Run provider scan before importing."
+                    ),
+                )
+            scan_candidates_raw = scan_doc.get("candidates")
+            if not isinstance(scan_candidates_raw, list):
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        "No scan candidates found for provider. "
+                        "Run provider scan before importing."
+                    ),
+                )
+
+            scan_candidates: Dict[str, Dict[str, str | None]] = {}
+            for candidate in scan_candidates_raw:
+                if not isinstance(candidate, dict):
+                    continue
+                model_id_raw = candidate.get("model_id")
+                if not isinstance(model_id_raw, str):
+                    continue
+                model_id = model_id_raw.strip()
+                if not model_id:
+                    continue
+                model_name_raw = candidate.get("model_name")
+                model_name = (
+                    model_name_raw.strip()
+                    if isinstance(model_name_raw, str) and model_name_raw.strip()
+                    else None
+                )
+                scan_candidates[model_id] = {
+                    "model_id": model_id,
+                    "model_name": model_name,
+                }
+
+            missing_from_scan_model_ids = sorted(
+                [model_id for model_id in selected_model_ids if model_id not in scan_candidates]
+            )
+
+            resolver = get_model_resolver()
+            provider_entries = [
+                entry for entry in resolver.catalog.entries if entry.provider == provider
+            ]
+            existing_by_native_id = {
+                entry.native_model_id: entry for entry in provider_entries
+            }
+            skipped_existing_model_ids = sorted(
+                [
+                    model_id
+                    for model_id in selected_model_ids
+                    if model_id in existing_by_native_id
+                ]
+            )
+
+            imported_path = _imported_catalog_yaml(provider)
+            imported_entries = _load_imported_catalog_entries(imported_path)
+
+            used_refs = {entry.ref.lower() for entry in resolver.catalog.entries}
+            for entry in imported_entries:
+                ref_value = entry.get("ref")
+                if isinstance(ref_value, str):
+                    used_refs.add(ref_value.strip().lower())
+
+            imported_items: List[CatalogImportItem] = []
+            for model_id in sorted(selected_model_ids):
+                if model_id in missing_from_scan_model_ids:
+                    continue
+                if model_id in skipped_existing_model_ids:
+                    continue
+
+                candidate = scan_candidates[model_id]
+                display_name = candidate.get("model_name") or model_id
+                ref = _next_available_ref(
+                    provider=provider, native_model_id=model_id, used_refs=used_refs
+                )
+                used_refs.add(ref.lower())
+
+                entry_doc: Dict[str, Any] = {
+                    "ref": ref,
+                    "provider": provider,
+                    "native_model_id": model_id,
+                    "display_name": display_name,
+                    "aliases": [],
+                    "status": "preview",
+                    "visibility": "hidden",
+                    "metadata": {"source": "imported"},
+                }
+                imported_entries.append(entry_doc)
+                imported_items.append(
+                    CatalogImportItem(
+                        canonical_ref=ref,
+                        provider=provider,
+                        native_model_id=model_id,
+                        display_name=display_name,
+                        source="imported",
+                    )
+                )
+
+            imported_entries = sorted(
+                imported_entries, key=lambda entry: str(entry.get("ref", "")).lower()
+            )
+            _write_yaml_with_parents(imported_path, {"entries": imported_entries})
+
+            data = CatalogImportResponse(
+                provider=provider,
+                imported=imported_items,
+                skipped_existing_model_ids=skipped_existing_model_ids,
+                missing_from_scan_model_ids=missing_from_scan_model_ids,
+            )
+            return SuccessResponse.create(
+                data=data, msg=f"Imported {len(imported_items)} catalog entries"
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to import catalog entries: {e}"
+            )
 
     @router.put(
         "/providers/{provider}/config",

--- a/python/valuecell/server/api/routers/models.py
+++ b/python/valuecell/server/api/routers/models.py
@@ -14,6 +14,7 @@ from valuecell.config.loader import get_config_loader
 from valuecell.config.manager import get_config_manager
 from valuecell.config.model_catalog import ModelCatalogEntry
 from valuecell.config.model_resolver import ModelResolution, ModelResolver
+from valuecell.adapters.models.provider_inventory import get_provider_inventory_source
 from valuecell.utils.env import get_system_env_path
 
 from ..schemas import SuccessResponse
@@ -194,7 +195,7 @@ def create_models_router() -> APIRouter:
                 return True
         return False
 
-    def _to_scan_candidates(provider: str) -> List[dict[str, str | None]]:
+    def _ensure_provider_exists(provider: str) -> None:
         manager = get_config_manager()
         cfg = manager.get_provider_config(provider)
         if cfg is None:
@@ -202,18 +203,20 @@ def create_models_router() -> APIRouter:
                 status_code=404, detail=f"Provider '{provider}' not found"
             )
 
+    async def _to_scan_candidates(provider: str) -> List[dict[str, str | None]]:
+        _ensure_provider_exists(provider)
+        inventory_source = get_provider_inventory_source()
+        inventory_models = await inventory_source.list_models(provider=provider)
+
         candidates: List[dict[str, str | None]] = []
-        for model in cfg.models or []:
-            if not isinstance(model, dict):
-                continue
-            model_id = str(model.get("id", "")).strip()
+        for model in inventory_models:
+            model_id = model.model_id.strip()
             if not model_id:
                 continue
-            model_name_raw = model.get("name")
-            model_name = None
-            if isinstance(model_name_raw, str):
-                normalized_name = model_name_raw.strip()
-                model_name = normalized_name if normalized_name else None
+            model_name_raw = model.model_name
+            model_name = model_name_raw.strip() if model_name_raw else None
+            if model_name == "":
+                model_name = None
             candidates.append({"model_id": model_id, "model_name": model_name})
 
         return candidates
@@ -508,7 +511,7 @@ def create_models_router() -> APIRouter:
     ) -> SuccessResponse[ProviderScanResponse]:
         try:
             scanned_at = datetime.now(timezone.utc).isoformat()
-            candidates = _to_scan_candidates(provider=provider)
+            candidates = await _to_scan_candidates(provider=provider)
             data = _build_scan_response(
                 provider=provider, scanned_at=scanned_at, candidates=candidates
             )
@@ -569,8 +572,8 @@ def create_models_router() -> APIRouter:
                     status_code=400, detail="At least one model_id must be provided"
                 )
 
-            # Ensure provider exists.
-            _to_scan_candidates(provider=provider)
+            # Ensure provider exists independently from scan state.
+            _ensure_provider_exists(provider=provider)
 
             scan_doc = _load_yaml(_scan_yaml(provider))
             if not isinstance(scan_doc, dict):

--- a/python/valuecell/server/api/schemas/model.py
+++ b/python/valuecell/server/api/schemas/model.py
@@ -182,3 +182,70 @@ class ResolveModelResponse(BaseModel):
     match_type: Literal["canonical_ref", "alias", "native_id", "legacy_id"] = Field(
         ..., description="How the resolver matched the input"
     )
+
+
+class ScanCandidateItem(BaseModel):
+    model_id: str = Field(..., description="Provider-native model id")
+    model_name: Optional[str] = Field(None, description="Provider model name")
+    catalog_ref: Optional[str] = Field(
+        None, description="Matched catalog ref if candidate already exists"
+    )
+    catalog_status: Optional[str] = Field(
+        None, description="Matched catalog status if candidate already exists"
+    )
+
+
+class ScanDiffReport(BaseModel):
+    new_model_ids: List[str] = Field(
+        default_factory=list, description="Scanned ids not currently in catalog"
+    )
+    missing_model_ids: List[str] = Field(
+        default_factory=list, description="Catalog ids not present in current scan"
+    )
+    renamed_model_ids: List[str] = Field(
+        default_factory=list,
+        description="Scanned ids whose names differ from catalog display names",
+    )
+    deprecated_model_ids: List[str] = Field(
+        default_factory=list, description="Scanned ids marked deprecated in catalog"
+    )
+
+
+class ProviderScanResponse(BaseModel):
+    provider: str = Field(..., description="Provider key")
+    scanned_at: str = Field(..., description="UTC scan timestamp in ISO-8601 format")
+    candidates: List[ScanCandidateItem] = Field(
+        default_factory=list, description="Scanned provider candidates"
+    )
+    report: ScanDiffReport = Field(
+        default_factory=ScanDiffReport, description="Scan diff report against catalog"
+    )
+
+
+class CatalogImportRequest(BaseModel):
+    provider: str = Field(..., description="Provider key for this import")
+    model_ids: List[str] = Field(
+        default_factory=list, description="Scanned model ids selected for import"
+    )
+
+
+class CatalogImportItem(BaseModel):
+    canonical_ref: str = Field(..., description="Canonical catalog ref")
+    provider: str = Field(..., description="Provider key")
+    native_model_id: str = Field(..., description="Provider-native model id")
+    display_name: str = Field(..., description="Catalog display name")
+    source: Literal["imported"] = Field(..., description="Catalog source marker")
+
+
+class CatalogImportResponse(BaseModel):
+    provider: str = Field(..., description="Provider key")
+    imported: List[CatalogImportItem] = Field(
+        default_factory=list, description="Imported catalog entries"
+    )
+    skipped_existing_model_ids: List[str] = Field(
+        default_factory=list, description="Selected model ids already present in catalog"
+    )
+    missing_from_scan_model_ids: List[str] = Field(
+        default_factory=list,
+        description="Selected model ids that were not found in latest scan state",
+    )

--- a/python/valuecell/server/api/tests/test_models_catalog_api.py
+++ b/python/valuecell/server/api/tests/test_models_catalog_api.py
@@ -3,8 +3,22 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from valuecell.config.loader import ConfigLoader
+from valuecell.config.manager import ConfigManager
 from valuecell.config.model_resolver import ModelResolver
 from valuecell.server.api.routers import models as models_router
+
+
+def _write_main_config(base_dir: Path) -> None:
+    (base_dir / "config.yaml").write_text(
+        """
+app:
+  name: test
+models:
+  primary_provider: openai
+""",
+        encoding="utf-8",
+    )
 
 
 def _write_catalog_file(base_dir: Path, filename: str, content: str) -> None:
@@ -20,6 +34,7 @@ def _write_provider_file(base_dir: Path, provider: str, content: str) -> None:
 
 
 def _prepare_config(tmp_path: Path) -> None:
+    _write_main_config(tmp_path)
     _write_catalog_file(
         tmp_path,
         "openai.yaml",
@@ -62,6 +77,8 @@ default_model: gpt-5
 models:
   - id: gpt-5
     name: GPT-5 Legacy
+  - id: gpt-next
+    name: GPT Next
 """,
     )
     _write_provider_file(
@@ -77,8 +94,16 @@ models:
 
 
 def _build_client(tmp_path: Path, monkeypatch) -> TestClient:
-    resolver = ModelResolver.from_config(config_dir=tmp_path)
-    monkeypatch.setattr(models_router, "get_model_resolver", lambda config_dir=None: resolver)
+    loader = ConfigLoader(config_dir=tmp_path)
+    manager = ConfigManager(loader=loader)
+    monkeypatch.setattr(models_router, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(
+        models_router,
+        "get_model_resolver",
+        lambda config_dir=None: ModelResolver.from_config(config_dir=tmp_path),
+    )
+    monkeypatch.setattr(models_router, "get_config_loader", lambda: loader)
+    monkeypatch.setattr(models_router, "get_config_manager", lambda: manager)
 
     app = FastAPI()
     app.include_router(models_router.create_models_router(), prefix="/api/v1")
@@ -234,3 +259,66 @@ def test_validate_invalid_explicit_model_ref_does_not_fallback(
     assert stages["resolved"] is False
     assert stages["native_model_id_present"] is False
     assert stages["reachable"] is False
+
+
+def test_scan_provider_persists_state_and_does_not_auto_import(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _prepare_config(tmp_path)
+    client = _build_client(tmp_path, monkeypatch)
+
+    response = client.post("/api/v1/models/providers/openai/scan")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["provider"] == "openai"
+    assert sorted(data["report"]["new_model_ids"]) == ["gpt-5", "gpt-next"]
+    assert data["report"]["missing_model_ids"] == ["gpt-5-2025-08-07"]
+    assert data["report"]["renamed_model_ids"] == []
+    assert data["report"]["deprecated_model_ids"] == []
+
+    scan_file = tmp_path / "models" / "scans" / "openai.yaml"
+    assert scan_file.exists() is True
+
+    catalog_response = client.get(
+        "/api/v1/models/catalog", params={"provider": "openai", "query": "gpt-next"}
+    )
+    assert catalog_response.status_code == 200
+    assert catalog_response.json()["data"] == []
+
+
+def test_import_catalog_from_scan_selected_model_ids_only(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _prepare_config(tmp_path)
+    client = _build_client(tmp_path, monkeypatch)
+
+    scan_response = client.post("/api/v1/models/providers/openai/scan")
+    assert scan_response.status_code == 200
+
+    import_response = client.post(
+        "/api/v1/models/catalog/import",
+        json={"provider": "openai", "model_ids": ["gpt-next", "gpt-not-in-scan"]},
+    )
+    assert import_response.status_code == 200
+    data = import_response.json()["data"]
+
+    assert data["provider"] == "openai"
+    assert len(data["imported"]) == 1
+    assert data["imported"][0]["native_model_id"] == "gpt-next"
+    assert data["imported"][0]["source"] == "imported"
+    assert data["skipped_existing_model_ids"] == []
+    assert data["missing_from_scan_model_ids"] == ["gpt-not-in-scan"]
+
+    imported_file = tmp_path / "models" / "catalog" / "openai.imported.yaml"
+    assert imported_file.exists() is True
+    imported_text = imported_file.read_text(encoding="utf-8")
+    assert "native_model_id: gpt-next" in imported_text
+    assert "visibility: hidden" in imported_text
+    assert "source: imported" in imported_text
+
+    catalog_response = client.get(
+        "/api/v1/models/catalog", params={"provider": "openai", "query": "gpt-next"}
+    )
+    assert catalog_response.status_code == 200
+    assert len(catalog_response.json()["data"]) == 1

--- a/python/valuecell/server/api/tests/test_models_catalog_api.py
+++ b/python/valuecell/server/api/tests/test_models_catalog_api.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from valuecell.adapters.models.provider_inventory import ProviderInventoryModel
 from valuecell.config.loader import ConfigLoader
 from valuecell.config.manager import ConfigManager
 from valuecell.config.model_resolver import ModelResolver
@@ -108,6 +109,14 @@ def _build_client(tmp_path: Path, monkeypatch) -> TestClient:
     app = FastAPI()
     app.include_router(models_router.create_models_router(), prefix="/api/v1")
     return TestClient(app)
+
+
+class _FakeProviderInventorySource:
+    def __init__(self, items_by_provider: dict[str, list[ProviderInventoryModel]]) -> None:
+        self._items_by_provider = items_by_provider
+
+    async def list_models(self, provider: str) -> list[ProviderInventoryModel]:
+        return list(self._items_by_provider.get(provider, []))
 
 
 def test_get_models_catalog_with_filters(tmp_path: Path, monkeypatch) -> None:
@@ -265,6 +274,19 @@ def test_scan_provider_persists_state_and_does_not_auto_import(
     tmp_path: Path, monkeypatch
 ) -> None:
     _prepare_config(tmp_path)
+    monkeypatch.setattr(
+        models_router,
+        "get_provider_inventory_source",
+        lambda: _FakeProviderInventorySource(
+            {
+                "openai": [
+                    ProviderInventoryModel(
+                        model_id="provider-scan-only", model_name="Provider Scan Only"
+                    )
+                ]
+            }
+        ),
+    )
     client = _build_client(tmp_path, monkeypatch)
 
     response = client.post("/api/v1/models/providers/openai/scan")
@@ -272,10 +294,11 @@ def test_scan_provider_persists_state_and_does_not_auto_import(
     assert response.status_code == 200
     data = response.json()["data"]
     assert data["provider"] == "openai"
-    assert sorted(data["report"]["new_model_ids"]) == ["gpt-5", "gpt-next"]
+    assert sorted(data["report"]["new_model_ids"]) == ["provider-scan-only"]
     assert data["report"]["missing_model_ids"] == ["gpt-5-2025-08-07"]
     assert data["report"]["renamed_model_ids"] == []
     assert data["report"]["deprecated_model_ids"] == []
+    assert [item["model_id"] for item in data["candidates"]] == ["provider-scan-only"]
 
     scan_file = tmp_path / "models" / "scans" / "openai.yaml"
     assert scan_file.exists() is True
@@ -291,6 +314,19 @@ def test_import_catalog_from_scan_selected_model_ids_only(
     tmp_path: Path, monkeypatch
 ) -> None:
     _prepare_config(tmp_path)
+    monkeypatch.setattr(
+        models_router,
+        "get_provider_inventory_source",
+        lambda: _FakeProviderInventorySource(
+            {
+                "openai": [
+                    ProviderInventoryModel(
+                        model_id="provider-scan-only", model_name="Provider Scan Only"
+                    )
+                ]
+            }
+        ),
+    )
     client = _build_client(tmp_path, monkeypatch)
 
     scan_response = client.post("/api/v1/models/providers/openai/scan")
@@ -298,14 +334,17 @@ def test_import_catalog_from_scan_selected_model_ids_only(
 
     import_response = client.post(
         "/api/v1/models/catalog/import",
-        json={"provider": "openai", "model_ids": ["gpt-next", "gpt-not-in-scan"]},
+        json={
+            "provider": "openai",
+            "model_ids": ["provider-scan-only", "gpt-not-in-scan"],
+        },
     )
     assert import_response.status_code == 200
     data = import_response.json()["data"]
 
     assert data["provider"] == "openai"
     assert len(data["imported"]) == 1
-    assert data["imported"][0]["native_model_id"] == "gpt-next"
+    assert data["imported"][0]["native_model_id"] == "provider-scan-only"
     assert data["imported"][0]["source"] == "imported"
     assert data["skipped_existing_model_ids"] == []
     assert data["missing_from_scan_model_ids"] == ["gpt-not-in-scan"]
@@ -313,12 +352,13 @@ def test_import_catalog_from_scan_selected_model_ids_only(
     imported_file = tmp_path / "models" / "catalog" / "openai.imported.yaml"
     assert imported_file.exists() is True
     imported_text = imported_file.read_text(encoding="utf-8")
-    assert "native_model_id: gpt-next" in imported_text
+    assert "native_model_id: provider-scan-only" in imported_text
     assert "visibility: hidden" in imported_text
     assert "source: imported" in imported_text
 
     catalog_response = client.get(
-        "/api/v1/models/catalog", params={"provider": "openai", "query": "gpt-next"}
+        "/api/v1/models/catalog",
+        params={"provider": "openai", "query": "provider-scan-only"},
     )
     assert catalog_response.status_code == 200
     assert len(catalog_response.json()["data"]) == 1


### PR DESCRIPTION
## Summary
- add provider scan API state for model inventory refresh without auto-promoting scan results
- add selected catalog import flow that writes imported entries separately from curated catalog files
- switch scan sourcing to a provider-facing inventory adapter/stub instead of reading local curated provider model lists
- add API coverage for scan persistence, decoupled scan sourcing, scan diff reporting, and selected import behavior

## Scope choice
This PR implements a thin backend slice toward issue #6:
- `POST /api/v1/models/providers/{provider}/scan`
- `POST /api/v1/models/catalog/import`
- persistence for scanned state and imported catalog entries
- provider-facing inventory adapter/stub for scan sourcing

It intentionally does **not** make runtime depend on raw scan output, and keeps imported entries hidden by default.
This should be read as a focused step toward #6 rather than a full close of the issue.

## Testing
- python/.venv/bin/pytest python/valuecell/server/api/tests/test_models_catalog_api.py
- cd python && UV_CACHE_DIR=/tmp/uv-cache uv run pytest valuecell/config/tests/test_model_catalog.py valuecell/config/tests/test_model_resolver.py
