### PR TITLE
feat: add minimax provider support

### DIFF
--- a/frontend/src/constants/icons.ts
+++ b/frontend/src/constants/icons.ts
@@ -27,6 +27,7 @@ export const MODEL_PROVIDER_ICONS = {
   google: GooglePng,
   azure: AzurePng,
   dashscope: DashScopePng,
+  minimax: OpenAiCompatiblePng,
   ollama: OllamaPng,
 };
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -173,6 +173,7 @@
       "dashscope": "Alibaba Cloud",
       "deepseek": "DeepSeek",
       "google": "Google Cloud",
+      "minimax": "MiniMax",
       "openai": "OpenAI",
       "openai-compatible": "OpenAI Compatible API",
       "openrouter": "OpenRouter",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -173,6 +173,7 @@
       "dashscope": "Alibaba Cloud",
       "deepseek": "DeepSeek",
       "google": "Google Cloud",
+      "minimax": "MiniMax",
       "openai": "OpenAI",
       "openai-compatible": "OpenAI互換API",
       "openrouter": "OpenRouter",

--- a/frontend/src/i18n/locales/zh_CN.json
+++ b/frontend/src/i18n/locales/zh_CN.json
@@ -173,6 +173,7 @@
       "dashscope": "阿里云",
       "deepseek": "深度求索",
       "google": "谷歌云",
+      "minimax": "MiniMax",
       "openai": "OpenAI",
       "openai-compatible": "OpenAI兼容API",
       "openrouter": "OpenRouter",

--- a/frontend/src/i18n/locales/zh_TW.json
+++ b/frontend/src/i18n/locales/zh_TW.json
@@ -173,6 +173,7 @@
       "dashscope": "Alibaba Cloud",
       "deepseek": "DeepSeek",
       "google": "Google Cloud",
+      "minimax": "MiniMax",
       "openai": "OpenAI",
       "openai-compatible": "OpenAI相容API",
       "openrouter": "OpenRouter",

--- a/python/configs/models/catalog/minimax.yaml
+++ b/python/configs/models/catalog/minimax.yaml
@@ -1,0 +1,26 @@
+entries:
+  - ref: minimax/minimax-m2.7
+    provider: minimax
+    native_model_id: MiniMax-M2.7
+    display_name: MiniMax M2.7
+    aliases:
+      - minimax-m2.7
+      - minimaxm27
+    status: stable
+    visibility: default
+    metadata:
+      family: minimax-m2.7
+      tier: flagship
+
+  - ref: minimax/minimax-m2.7-highspeed
+    provider: minimax
+    native_model_id: MiniMax-M2.7-highspeed
+    display_name: MiniMax M2.7 Highspeed
+    aliases:
+      - minimax-m2.7-highspeed
+      - minimaxm27-highspeed
+    status: stable
+    visibility: default
+    metadata:
+      family: minimax-m2.7
+      tier: fast

--- a/python/configs/providers/minimax.yaml
+++ b/python/configs/providers/minimax.yaml
@@ -1,0 +1,43 @@
+# ============================================
+# MiniMax Provider Configuration
+# ============================================
+# MiniMax exposes an OpenAI-compatible chat endpoint.
+# Configure the API key via MINIMAX_API_KEY.
+
+name: MiniMax
+provider_type: minimax
+enabled: true
+
+connection:
+  base_url: https://api.minimax.io/v1
+  api_key_env: MINIMAX_API_KEY
+
+default_model: MiniMax-M2.7
+default_model_ref: minimax/minimax-m2.7
+
+recommended_models:
+  - minimax/minimax-m2.7
+  - minimax/minimax-m2.7-highspeed
+
+defaults:
+  temperature: 0.7
+  max_tokens: 4096
+
+models:
+  - id: MiniMax-M2.7
+    name: MiniMax M2.7
+    context_length: 204800
+    description: MiniMax M2.7 model via OpenAI-compatible API
+    supported_inputs:
+      - text
+    supported_outputs:
+      - text
+
+  - id: MiniMax-M2.7-highspeed
+    name: MiniMax M2.7 Highspeed
+    context_length: 204800
+    description: MiniMax M2.7 highspeed model via OpenAI-compatible API
+    supported_inputs:
+      - text
+    supported_outputs:
+      - text

--- a/python/valuecell/adapters/models/__init__.py
+++ b/python/valuecell/adapters/models/__init__.py
@@ -26,6 +26,7 @@ from valuecell.adapters.models.factory import (
     GoogleProvider,
     ModelFactory,
     ModelProvider,
+    MinimaxProvider,
     OllamaProvider,
     OpenAICompatibleProvider,
     OpenAIProvider,
@@ -50,6 +51,7 @@ __all__ = [
     "SiliconFlowProvider",
     "DeepSeekProvider",
     "DashScopeProvider",
+    "MinimaxProvider",
     "OllamaProvider",
     # Convenience functions
     "create_model",

--- a/python/valuecell/adapters/models/factory.py
+++ b/python/valuecell/adapters/models/factory.py
@@ -565,6 +565,14 @@ class DashScopeProvider(ModelProvider):
         )
 
 
+class MinimaxProvider(OpenAICompatibleProvider):
+    """MiniMax provider.
+
+    MiniMax provides an OpenAI-compatible chat API, so we reuse OpenAILike
+    behavior from OpenAICompatibleProvider.
+    """
+
+
 class OllamaProvider(ModelProvider):
     """Ollama model provider"""
 
@@ -609,6 +617,7 @@ class ModelFactory:
         "openai-compatible": OpenAICompatibleProvider,
         "deepseek": DeepSeekProvider,
         "dashscope": DashScopeProvider,
+        "minimax": MinimaxProvider,
         "ollama": OllamaProvider,
     }
 

--- a/python/valuecell/adapters/models/tests/test_model_ref_resolution.py
+++ b/python/valuecell/adapters/models/tests/test_model_ref_resolution.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from valuecell.adapters.models.factory import ModelFactory
+from valuecell.adapters.models.factory import MinimaxProvider, ModelFactory
 from valuecell.config.loader import ConfigLoader
 from valuecell.config.manager import ConfigManager
 
@@ -119,3 +119,7 @@ def test_create_model_uses_provider_default_model_ref(
 
     assert result["provider"] == "openai"
     assert result["model_id"] == "gpt-5-2025-08-07"
+
+
+def test_model_factory_registers_minimax_provider() -> None:
+    assert ModelFactory._providers["minimax"] is MinimaxProvider

--- a/python/valuecell/server/api/routers/models.py
+++ b/python/valuecell/server/api/routers/models.py
@@ -165,6 +165,7 @@ def create_models_router() -> APIRouter:
             "siliconflow": "https://cloud.siliconflow.cn/account/ak",
             "deepseek": "https://platform.deepseek.com/api_keys",
             "dashscope": "https://bailian.console.aliyun.com/#/home",
+            "minimax": "https://platform.minimax.io/",
             "ollama": None,
         }
         return mapping.get(provider)
@@ -1360,6 +1361,10 @@ def create_models_router() -> APIRouter:
                             f"{bu}/compatible-mode/v1/chat/completions",
                             "openai_like",
                         )
+                    if "minimax.io" in lower:
+                        return f"{bu}/v1/chat/completions" if not lower.endswith(
+                            "/v1"
+                        ) else f"{bu}/chat/completions", "openai_like"
                     # If base_url provided but host is unrecognized:
                     # - For openai-compatible, treat as generic OpenAI-like
                     # - For Google/Azure, ignore base_url and fall through to provider fallback
@@ -1403,6 +1408,8 @@ def create_models_router() -> APIRouter:
                         "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
                         "openai_like",
                     )
+                if provider == "minimax":
+                    return "https://api.minimax.io/v1/chat/completions", "openai_like"
                 if provider == "openai-compatible":
                     if base_url:
                         bu = _normalize_base_url(base_url)
@@ -1421,6 +1428,7 @@ def create_models_router() -> APIRouter:
                         "openrouter",
                         "deepseek",
                         "siliconflow",
+                        "minimax",
                         "azure",
                         "google",
                     }:

--- a/python/valuecell/server/api/tests/test_models_catalog_api.py
+++ b/python/valuecell/server/api/tests/test_models_catalog_api.py
@@ -362,3 +362,39 @@ def test_import_catalog_from_scan_selected_model_ids_only(
     )
     assert catalog_response.status_code == 200
     assert len(catalog_response.json()["data"]) == 1
+
+
+def test_minimax_provider_detail_and_validate_missing_api_key(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _prepare_config(tmp_path)
+    _write_provider_file(
+        tmp_path,
+        "minimax",
+        """
+connection:
+  base_url: https://api.minimax.io/v1
+  api_key_env: MINIMAX_API_KEY
+default_model: MiniMax-M2.7
+models:
+  - id: MiniMax-M2.7
+    name: MiniMax M2.7
+""",
+    )
+    client = _build_client(tmp_path, monkeypatch)
+
+    detail_response = client.get("/api/v1/models/providers/minimax")
+    assert detail_response.status_code == 200
+    detail = detail_response.json()["data"]
+    assert detail["api_key_url"] == "https://platform.minimax.io/"
+    assert detail["default_model_id"] == "MiniMax-M2.7"
+
+    validate_response = client.post(
+        "/api/v1/models/validate",
+        json={"provider": "minimax", "model_id": "MiniMax-M2.7"},
+    )
+    assert validate_response.status_code == 200
+    data = validate_response.json()["data"]
+    assert data["ok"] is False
+    assert data["status"] == "auth_failed"
+    assert data["error"] == "API key is missing"


### PR DESCRIPTION
## Summary
- add a dedicated minimax provider config and minimal catalog entries
- register Minimax in the model factory by reusing the OpenAI-compatible implementation
- expose minimax in provider metadata, API details, tests, and frontend labels/icons

## Validation
- python: `/tmp/vc-venv/bin/python -m pytest valuecell/adapters/models/tests/test_model_ref_resolution.py -v`
- attempted `valuecell/server/api/tests/test_models_catalog_api.py`, but local run hit missing transitive deps in this environment
