### PR TITLE
ci: add product-path API smoke test and split test layers (issue #18 slice)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -76,8 +76,11 @@ jobs:
       - name: Install the project
         run: uv sync --locked --all-extras --dev
 
-      - name: Run tests
+      - name: Run core tests
         run: uv run pytest valuecell/core/ --cov=valuecell.core --cov-report=xml --cov-report=term
+
+      - name: Run product smoke tests
+        run: uv run pytest valuecell/server/api/tests/test_app_smoke.py
 
       - name: Check coverage
         run: |

--- a/python/valuecell/server/api/tests/test_app_smoke.py
+++ b/python/valuecell/server/api/tests/test_app_smoke.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+import valuecell.server.api.app as app_module
+
+
+def _empty_router() -> APIRouter:
+    return APIRouter()
+
+
+def test_app_product_path_smoke(monkeypatch, tmp_path: Path) -> None:
+    """Smoke test app factory and product-path health endpoints."""
+    db_path = tmp_path / "smoke.db"
+    monkeypatch.setenv("VALUECELL_DATABASE_URL", f"sqlite:///{db_path}")
+
+    # Keep smoke stable by skipping heavyweight router initialization side effects.
+    monkeypatch.setattr(app_module, "create_agent_stream_router", _empty_router)
+    monkeypatch.setattr(app_module, "create_strategy_api_router", _empty_router)
+
+    app_module.get_settings.cache_clear()
+    app = app_module.create_app()
+    client = TestClient(app)
+
+    root_response = client.get("/")
+    assert root_response.status_code == 200
+    root_payload = root_response.json()
+    assert root_payload["code"] == 0
+    assert root_payload["data"]["name"]
+    assert root_payload["data"]["version"]
+    assert root_payload["data"]["environment"]
+
+    healthz_response = client.get("/api/v1/healthz")
+    assert healthz_response.status_code == 200
+    healthz_payload = healthz_response.json()
+    assert healthz_payload["code"] == 0
+    assert healthz_payload["msg"] == "Welcome to ValueCell!"
+
+    system_health_response = client.get("/api/v1/system/health")
+    assert system_health_response.status_code == 200
+    system_health_payload = system_health_response.json()
+    assert system_health_payload["code"] == 0
+    assert system_health_payload["data"]["status"] == "healthy"


### PR DESCRIPTION
## Summary
This PR delivers a focused slice for issue #18 by extending CI beyond core-only tests with one stable product-path smoke check.

## What changed
- Added `valuecell/server/api/tests/test_app_smoke.py`
  - Verifies app factory + key product-path endpoints:
    - `GET /`
    - `GET /api/v1/healthz`
    - `GET /api/v1/system/health`
  - Uses minimal monkeypatching for heavyweight router init points to keep smoke deterministic.
- Updated `.github/workflows/python.yml`
  - Renamed existing step to `Run core tests` (coverage behavior unchanged).
  - Added `Run product smoke tests` step for the new API smoke test.

## Why
Current CI only validates `valuecell/core`. This adds a lightweight integration-lite signal for actual product entry paths without broad refactor or risky test expansion.

## Scope note
This is a thin, focused step toward issue #18; it does **not** fully close the issue yet.

## Validation
- `UV_CACHE_DIR=../.uv-cache uv run pytest valuecell/server/api/tests/test_app_smoke.py -q` -> passed
- `UV_CACHE_DIR=../.uv-cache uv run pytest valuecell/server/api/tests/test_models_catalog_api.py::test_get_models_catalog_with_filters -q` -> passed
- `UV_CACHE_DIR=../.uv-cache uv run pytest valuecell/core/event/tests/test_response_factory.py -q` -> passed
