### PR TITLE
ci: add integration-lite lane for issue 18

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -76,8 +76,15 @@ jobs:
       - name: Install the project
         run: uv sync --locked --all-extras --dev
 
-      - name: Run core tests
+      - name: Run unit tests
         run: uv run pytest valuecell/core/ --cov=valuecell.core --cov-report=xml --cov-report=term
+
+      - name: Run integration-lite tests
+        run: |
+          uv run pytest \
+            valuecell/server/api/tests/test_models_catalog_api.py \
+            valuecell/agents/research_agent/tests/test_fault_tolerance.py \
+            valuecell/adapters/models/tests/test_model_ref_resolution.py
 
       - name: Run product smoke tests
         run: uv run pytest valuecell/server/api/tests/test_app_smoke.py


### PR DESCRIPTION
## Summary
- split Python CI test reporting into unit / integration-lite / smoke layers
- keep existing core coverage lane intact while adding focused default regression coverage for server, agent, and adapter paths
- reuse existing stable tests instead of broadening CI with noisy or network-heavy suites

## What changed
- rename the core test step to `Run unit tests`
- add `Run integration-lite tests` covering:
  - `valuecell/server/api/tests/test_models_catalog_api.py`
  - `valuecell/agents/research_agent/tests/test_fault_tolerance.py`
  - `valuecell/adapters/models/tests/test_model_ref_resolution.py`
- keep `Run product smoke tests` on `test_app_smoke.py`

## Validation
- `/Users/mn/Projects/valuecell/python/.venv/bin/pytest /Users/mn/Projects/valuecell/python/valuecell/core -q`
- `/Users/mn/Projects/valuecell/python/.venv/bin/pytest /Users/mn/Projects/valuecell/python/valuecell/server/api/tests/test_models_catalog_api.py /Users/mn/Projects/valuecell/python/valuecell/agents/research_agent/tests/test_fault_tolerance.py /Users/mn/Projects/valuecell/python/valuecell/adapters/models/tests/test_model_ref_resolution.py -q`
- `/Users/mn/Projects/valuecell/python/.venv/bin/pytest /Users/mn/Projects/valuecell/python/valuecell/server/api/tests/test_app_smoke.py -q`

## Notes
- This is still a thin slice toward issue #18, not the full issue closure.
