### PR TITLE
test: add thin frontend behavior coverage for issue 19

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -51,6 +51,26 @@ jobs:
       - name: Run type checking
         run: bun run typecheck
 
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: "./frontend/package.json"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run behavior tests
+        run: bun run test
+
   build:
     runs-on: ubuntu-latest
     defaults:

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "files": {
     "includes": [
       "src/**/*.{ts,tsx,js,jsx}",
@@ -53,17 +53,12 @@
         "useExhaustiveDependencies": "warn"
       },
       "nursery": {
-        "noImportCycles": "off",
         "useSortedClasses": {
           "fix": "safe",
           "level": "error",
           "options": {
-            "attributes": [
-              "className"
-            ],
-            "functions": [
-              "cn"
-            ]
+            "attributes": ["className"],
+            "functions": ["cn"]
           }
         }
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "build": "react-router build",
     "start": "vite preview --outDir build/client",
     "typecheck": "react-router typegen && tsc",
+    "test": "bun test",
     "lint": "biome lint --diagnostic-level=error ./src",
     "lint:fix": "biome lint --write ./src",
     "format": "biome format --diagnostic-level=error ./src",

--- a/frontend/src/app/agent/components/strategy-items/portfolio-positions-group.tsx
+++ b/frontend/src/app/agent/components/strategy-items/portfolio-positions-group.tsx
@@ -276,9 +276,9 @@ const PortfolioPositionsGroup: FC<PortfolioPositionsGroupProps> = ({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {positions.map((position, index) => (
+              {positions.map((position) => (
                 <PositionRow
-                  key={`${position.symbol}-${index}`}
+                  key={`${position.symbol}-${position.type}-${position.leverage}-${position.quantity}`}
                   position={position}
                 />
               ))}

--- a/frontend/src/app/home/components/agent-suggestions-list.tsx
+++ b/frontend/src/app/home/components/agent-suggestions-list.tsx
@@ -1,3 +1,4 @@
+import { Children, isValidElement } from "react";
 import {
   AgentMenuCard,
   AgentMenuContent,
@@ -98,9 +99,13 @@ function AgentSuggestionItem({
         {suggestion.avatars && suggestion.avatars.length > 0 && (
           <AgentMenuSuffix>
             <div className="flex items-center">
-              {suggestion.avatars.map((avatar, index) => (
+              {Children.toArray(suggestion.avatars).map((avatar) => (
                 <div
-                  key={`${suggestion.id}-avatar-${index}`}
+                  key={
+                    isValidElement(avatar) && avatar.key != null
+                      ? String(avatar.key)
+                      : `${suggestion.id}-${String(avatar)}`
+                  }
                   className="relative -mr-2 size-6 overflow-hidden rounded-full border-2 border-background last:mr-0"
                 >
                   {avatar}
@@ -146,4 +151,4 @@ function AgentSuggestionsList({
   );
 }
 
-export { AgentSuggestionsList, AgentSuggestionsHeader, AgentSuggestionItem };
+export { AgentSuggestionItem, AgentSuggestionsHeader, AgentSuggestionsList };

--- a/frontend/src/app/setting/components/models/model-detail.tsx
+++ b/frontend/src/app/setting/components/models/model-detail.tsx
@@ -430,7 +430,8 @@ export function ModelDetail({ provider }: ModelDetailProps) {
                       <span className="font-normal text-foreground text-sm">
                         {model.model_name}
                       </span>
-                      {model.catalogStatus && model.catalogStatus !== "stable" ? (
+                      {model.catalogStatus &&
+                      model.catalogStatus !== "stable" ? (
                         <span className="text-muted-foreground text-xs uppercase">
                           {model.catalogStatus}
                         </span>
@@ -440,7 +441,9 @@ export function ModelDetail({ provider }: ModelDetailProps) {
                     <div className="flex items-center gap-3">
                       <Switch
                         className="cursor-pointer"
-                        checked={model.model_id === providerDetail.default_model_id}
+                        checked={
+                          model.model_id === providerDetail.default_model_id
+                        }
                         disabled={isBusy}
                         onCheckedChange={() =>
                           handleSetDefaultModel(model.model_id)

--- a/frontend/src/components/valuecell/form/ai-model-form.tsx
+++ b/frontend/src/components/valuecell/form/ai-model-form.tsx
@@ -12,6 +12,127 @@ import PngIcon from "@/components/valuecell/icon/png-icon";
 import { MODEL_PROVIDER_ICONS } from "@/constants/icons";
 import { withForm } from "@/hooks/use-form";
 
+function AIModelFormRender({ form }: { form: any }) {
+  const { t } = useTranslation();
+  const {
+    providers: sortedProviders,
+    defaultProvider,
+    isLoading: isLoadingProviders,
+  } = useGetSortedModelProviders();
+
+  const provider = useStore(form.store, (state: any) => state.values.provider);
+  const {
+    isLoading: isLoadingModelProviderDetail,
+    data: modelProviderDetail,
+    refetch: fetchModelProviderDetail,
+  } = useGetModelProviderDetail(provider);
+  const { isLoading: isLoadingModelCatalog, data: modelCatalog = [] } =
+    useGetModelCatalog(provider);
+
+  useEffect(() => {
+    if (isLoadingProviders || !defaultProvider) return;
+    if (!provider) {
+      form.setFieldValue("provider", defaultProvider);
+    }
+  }, [isLoadingProviders, defaultProvider, provider, form]);
+
+  if (
+    isLoadingProviders ||
+    isLoadingModelProviderDetail ||
+    isLoadingModelCatalog
+  ) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <FieldGroup className="gap-6">
+      <form.AppField
+        listeners={{
+          onMount: async () => {
+            const { data } = await fetchModelProviderDetail();
+            form.setFieldValue("api_key", data?.api_key ?? "");
+          },
+          onChange: async () => {
+            const { data } = await fetchModelProviderDetail();
+
+            form.setFieldValue("model_id", data?.default_model_id ?? "");
+            form.setFieldValue("api_key", data?.api_key ?? "");
+          },
+        }}
+        name="provider"
+      >
+        {(field: any) => (
+          <field.SelectField label={t("strategy.form.aiModels.platform")}>
+            {sortedProviders.map(({ provider }) => (
+              <SelectItem key={provider} value={provider}>
+                <div className="flex items-center gap-2">
+                  <PngIcon
+                    src={
+                      MODEL_PROVIDER_ICONS[
+                        provider as keyof typeof MODEL_PROVIDER_ICONS
+                      ]
+                    }
+                    className="size-4"
+                  />
+                  {t(`strategy.providers.${provider}`) || provider}
+                </div>
+              </SelectItem>
+            ))}
+          </field.SelectField>
+        )}
+      </form.AppField>
+
+      <form.AppField name="model_id">
+        {(field: any) => {
+          const catalogByNativeId = new Map(
+            modelCatalog.map((entry) => [entry.native_model_id, entry]),
+          );
+          const models = (modelProviderDetail?.models || []).map((model) => {
+            const catalogEntry = catalogByNativeId.get(model.model_id);
+            return {
+              model_id: model.model_id,
+              model_name:
+                catalogEntry?.display_name ||
+                model.model_name ||
+                model.model_id,
+              metaLabel:
+                catalogEntry?.status && catalogEntry.status !== "stable"
+                  ? catalogEntry.status
+                  : catalogEntry?.provider || provider,
+            };
+          });
+
+          return (
+            <field.SelectField label={t("strategy.form.aiModels.model")}>
+              {models.map((model) => (
+                <SelectItem key={model.model_id} value={model.model_id}>
+                  <div className="flex w-full items-center justify-between gap-3">
+                    <span>{model.model_name}</span>
+                    {model.metaLabel ? (
+                      <span className="text-muted-foreground text-xs uppercase">
+                        {model.metaLabel}
+                      </span>
+                    ) : null}
+                  </div>
+                </SelectItem>
+              ))}
+            </field.SelectField>
+          );
+        }}
+      </form.AppField>
+
+      <form.AppField name="api_key">
+        {(field: any) => (
+          <field.PasswordField
+            label={t("strategy.form.aiModels.apiKey.label")}
+            placeholder={t("strategy.form.aiModels.apiKey.placeholder")}
+          />
+        )}
+      </form.AppField>
+    </FieldGroup>
+  );
+}
+
 export const AIModelForm = withForm({
   defaultValues: {
     model_id: "",
@@ -20,123 +141,6 @@ export const AIModelForm = withForm({
   },
 
   render({ form }) {
-    const { t } = useTranslation();
-    const {
-      providers: sortedProviders,
-      defaultProvider,
-      isLoading: isLoadingProviders,
-    } = useGetSortedModelProviders();
-
-    const provider = useStore(form.store, (state) => state.values.provider);
-    const {
-      isLoading: isLoadingModelProviderDetail,
-      data: modelProviderDetail,
-      refetch: fetchModelProviderDetail,
-    } = useGetModelProviderDetail(provider);
-    const {
-      isLoading: isLoadingModelCatalog,
-      data: modelCatalog = [],
-    } = useGetModelCatalog(provider);
-
-    useEffect(() => {
-      if (isLoadingProviders || !defaultProvider) return;
-      if (!provider) {
-        form.setFieldValue("provider", defaultProvider);
-      }
-    }, [isLoadingProviders, defaultProvider, provider, form]);
-
-    if (
-      isLoadingProviders ||
-      isLoadingModelProviderDetail ||
-      isLoadingModelCatalog
-    ) {
-      return <div>Loading...</div>;
-    }
-
-    return (
-      <FieldGroup className="gap-6">
-        <form.AppField
-          listeners={{
-            onMount: async () => {
-              const { data } = await fetchModelProviderDetail();
-              form.setFieldValue("api_key", data?.api_key ?? "");
-            },
-            onChange: async () => {
-              const { data } = await fetchModelProviderDetail();
-
-              form.setFieldValue("model_id", data?.default_model_id ?? "");
-              form.setFieldValue("api_key", data?.api_key ?? "");
-            },
-          }}
-          name="provider"
-        >
-          {(field) => (
-            <field.SelectField label={t("strategy.form.aiModels.platform")}>
-              {sortedProviders.map(({ provider }) => (
-                <SelectItem key={provider} value={provider}>
-                  <div className="flex items-center gap-2">
-                    <PngIcon
-                      src={
-                        MODEL_PROVIDER_ICONS[
-                          provider as keyof typeof MODEL_PROVIDER_ICONS
-                        ]
-                      }
-                      className="size-4"
-                    />
-                    {t(`strategy.providers.${provider}`) || provider}
-                  </div>
-                </SelectItem>
-              ))}
-            </field.SelectField>
-          )}
-        </form.AppField>
-
-        <form.AppField name="model_id">
-          {(field) => {
-            const catalogByNativeId = new Map(
-              modelCatalog.map((entry) => [entry.native_model_id, entry]),
-            );
-            const models = (modelProviderDetail?.models || []).map((model) => {
-              const catalogEntry = catalogByNativeId.get(model.model_id);
-              return {
-                model_id: model.model_id,
-                model_name:
-                  catalogEntry?.display_name || model.model_name || model.model_id,
-                metaLabel:
-                  catalogEntry?.status && catalogEntry.status !== "stable"
-                    ? catalogEntry.status
-                    : catalogEntry?.provider || provider,
-              };
-            });
-
-            return (
-              <field.SelectField label={t("strategy.form.aiModels.model")}>
-                {models.map((model) => (
-                  <SelectItem key={model.model_id} value={model.model_id}>
-                    <div className="flex w-full items-center justify-between gap-3">
-                      <span>{model.model_name}</span>
-                      {model.metaLabel ? (
-                        <span className="text-muted-foreground text-xs uppercase">
-                          {model.metaLabel}
-                        </span>
-                      ) : null}
-                    </div>
-                  </SelectItem>
-                ))}
-              </field.SelectField>
-            );
-          }}
-        </form.AppField>
-
-        <form.AppField name="api_key">
-          {(field) => (
-            <field.PasswordField
-              label={t("strategy.form.aiModels.apiKey.label")}
-              placeholder={t("strategy.form.aiModels.apiKey.placeholder")}
-            />
-          )}
-        </form.AppField>
-      </FieldGroup>
-    );
+    return <AIModelFormRender form={form} />;
   },
 });

--- a/frontend/src/components/valuecell/form/exchange-form.tsx
+++ b/frontend/src/components/valuecell/form/exchange-form.tsx
@@ -118,6 +118,208 @@ const getPlaceholder = (
   return "";
 };
 
+function ExchangeFormRender({ form }: { form: any }) {
+  const { t } = useTranslation();
+  const { mutateAsync: testConnection, isPending } = useTestConnection();
+  const [testStatus, setTestStatus] = useState<{
+    success: boolean;
+    message: string;
+  } | null>(null);
+
+  const handleTestConnection = async () => {
+    setTestStatus(null);
+    try {
+      await testConnection(form.state.values);
+      setTestStatus({
+        success: true,
+        message: t("strategy.form.exchanges.test.success"),
+      });
+    } catch (_error) {
+      setTestStatus({
+        success: false,
+        message: t("strategy.form.exchanges.test.failed"),
+      });
+    }
+  };
+
+  return (
+    <FieldGroup className="gap-4">
+      <form.AppField
+        listeners={{
+          onChange: ({ value }: { value: any }) => {
+            form.reset({
+              trading_mode: value,
+              exchange_id: value === "live" ? "okx" : "",
+              api_key: "",
+              secret_key: "",
+              passphrase: "",
+              wallet_address: "",
+              private_key: "",
+            });
+          },
+        }}
+        name="trading_mode"
+      >
+        {(field: any) => (
+          <field.RadioField
+            label={t("strategy.form.exchanges.transactionType")}
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="live" id="live" />
+              <Label htmlFor="live" className="text-sm">
+                {t("strategy.form.exchanges.liveTrading")}
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="virtual" id="virtual" />
+              <Label htmlFor="virtual" className="text-sm">
+                {t("strategy.form.exchanges.virtualTrading")}
+              </Label>
+            </div>
+          </field.RadioField>
+        )}
+      </form.AppField>
+
+      <form.Subscribe selector={(state: any) => state.values.trading_mode}>
+        {(tradingMode: any) => {
+          return (
+            tradingMode === "live" && (
+              <>
+                <form.AppField name="exchange_id">
+                  {(field: any) => (
+                    <field.SelectField
+                      label={t("strategy.form.exchanges.selectExchange")}
+                    >
+                      {EXCHANGE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          <div className="flex items-center gap-2">
+                            <PngIcon
+                              src={
+                                EXCHANGE_ICONS[
+                                  option.value as keyof typeof EXCHANGE_ICONS
+                                ]
+                              }
+                            />
+                            {option.label}
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </field.SelectField>
+                  )}
+                </form.AppField>
+
+                <form.Subscribe
+                  selector={(state: any) => state.values.exchange_id}
+                >
+                  {(exchangeId: any) => {
+                    return exchangeId === "hyperliquid" ? (
+                      <>
+                        <form.AppField name="wallet_address">
+                          {(field: any) => (
+                            <field.TextField
+                              label={t("strategy.form.exchanges.walletAddress")}
+                              placeholder={getPlaceholder(
+                                exchangeId || "",
+                                "wallet_address",
+                                t,
+                              )}
+                            />
+                          )}
+                        </form.AppField>
+                        <form.AppField name="private_key">
+                          {(field: any) => (
+                            <field.PasswordField
+                              label={t("strategy.form.exchanges.privateKey")}
+                              placeholder={getPlaceholder(
+                                exchangeId || "",
+                                "private_key",
+                                t,
+                              )}
+                            />
+                          )}
+                        </form.AppField>
+                      </>
+                    ) : (
+                      <>
+                        <form.AppField name="api_key">
+                          {(field: any) => (
+                            <field.PasswordField
+                              label={t("strategy.form.exchanges.apiKey")}
+                              placeholder={getPlaceholder(
+                                exchangeId || "",
+                                "api_key",
+                                t,
+                              )}
+                            />
+                          )}
+                        </form.AppField>
+                        <form.AppField name="secret_key">
+                          {(field: any) => (
+                            <field.PasswordField
+                              label={t("strategy.form.exchanges.secretKey")}
+                              placeholder={getPlaceholder(
+                                exchangeId || "",
+                                "secret_key",
+                                t,
+                              )}
+                            />
+                          )}
+                        </form.AppField>
+
+                        {(exchangeId === "okx" ||
+                          exchangeId === "coinbaseexchange") && (
+                          <form.AppField name="passphrase">
+                            {(field: any) => (
+                              <field.PasswordField
+                                label={t("strategy.form.exchanges.passphrase")}
+                                placeholder={getPlaceholder(
+                                  exchangeId || "",
+                                  "passphrase",
+                                  t,
+                                )}
+                              />
+                            )}
+                          </form.AppField>
+                        )}
+                      </>
+                    );
+                  }}
+                </form.Subscribe>
+
+                <div className="-mt-2 flex flex-col gap-2">
+                  {testStatus && (
+                    <p
+                      className={`font-medium text-sm ${
+                        testStatus.success ? "text-green-600" : "text-red-600"
+                      }`}
+                    >
+                      {testStatus.message}
+                    </p>
+                  )}
+                  <Button
+                    variant="outline"
+                    className="w-full gap-2 py-4 font-medium text-base"
+                    onClick={handleTestConnection}
+                    disabled={isPending}
+                    type="button"
+                  >
+                    {isPending ? (
+                      <Spinner className="size-5 text-muted-foreground" />
+                    ) : (
+                      <Wallet className="size-5" />
+                    )}
+                    {t("strategy.form.exchanges.testConnection")}
+                  </Button>
+                </div>
+              </>
+            )
+          );
+        }}
+      </form.Subscribe>
+    </FieldGroup>
+  );
+}
+
 export const ExchangeForm = withForm({
   defaultValues: {
     trading_mode: "live" as "live" | "virtual",
@@ -129,208 +331,6 @@ export const ExchangeForm = withForm({
     private_key: "",
   },
   render({ form }) {
-    const { t } = useTranslation();
-    const { mutateAsync: testConnection, isPending } = useTestConnection();
-    const [testStatus, setTestStatus] = useState<{
-      success: boolean;
-      message: string;
-    } | null>(null);
-
-    const handleTestConnection = async () => {
-      setTestStatus(null);
-      try {
-        await testConnection(form.state.values);
-        setTestStatus({
-          success: true,
-          message: t("strategy.form.exchanges.test.success"),
-        });
-      } catch (_error) {
-        setTestStatus({
-          success: false,
-          message: t("strategy.form.exchanges.test.failed"),
-        });
-      }
-    };
-
-    return (
-      <FieldGroup className="gap-4">
-        <form.AppField
-          listeners={{
-            onChange: ({ value }) => {
-              form.reset({
-                trading_mode: value,
-                exchange_id: value === "live" ? "okx" : "",
-                api_key: "",
-                secret_key: "",
-                passphrase: "",
-                wallet_address: "",
-                private_key: "",
-              });
-            },
-          }}
-          name="trading_mode"
-        >
-          {(field) => (
-            <field.RadioField
-              label={t("strategy.form.exchanges.transactionType")}
-            >
-              <div className="flex items-center gap-2">
-                <RadioGroupItem value="live" id="live" />
-                <Label htmlFor="live" className="text-sm">
-                  {t("strategy.form.exchanges.liveTrading")}
-                </Label>
-              </div>
-              <div className="flex items-center gap-2">
-                <RadioGroupItem value="virtual" id="virtual" />
-                <Label htmlFor="virtual" className="text-sm">
-                  {t("strategy.form.exchanges.virtualTrading")}
-                </Label>
-              </div>
-            </field.RadioField>
-          )}
-        </form.AppField>
-
-        <form.Subscribe selector={(state) => state.values.trading_mode}>
-          {(tradingMode) => {
-            return (
-              tradingMode === "live" && (
-                <>
-                  <form.AppField name="exchange_id">
-                    {(field) => (
-                      <field.SelectField
-                        label={t("strategy.form.exchanges.selectExchange")}
-                      >
-                        {EXCHANGE_OPTIONS.map((option) => (
-                          <SelectItem key={option.value} value={option.value}>
-                            <div className="flex items-center gap-2">
-                              <PngIcon
-                                src={
-                                  EXCHANGE_ICONS[
-                                    option.value as keyof typeof EXCHANGE_ICONS
-                                  ]
-                                }
-                              />
-                              {option.label}
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </field.SelectField>
-                    )}
-                  </form.AppField>
-
-                  <form.Subscribe
-                    selector={(state) => state.values.exchange_id}
-                  >
-                    {(exchangeId) => {
-                      return exchangeId === "hyperliquid" ? (
-                        <>
-                          <form.AppField name="wallet_address">
-                            {(field) => (
-                              <field.TextField
-                                label={t(
-                                  "strategy.form.exchanges.walletAddress",
-                                )}
-                                placeholder={getPlaceholder(
-                                  exchangeId || "",
-                                  "wallet_address",
-                                  t,
-                                )}
-                              />
-                            )}
-                          </form.AppField>
-                          <form.AppField name="private_key">
-                            {(field) => (
-                              <field.PasswordField
-                                label={t("strategy.form.exchanges.privateKey")}
-                                placeholder={getPlaceholder(
-                                  exchangeId || "",
-                                  "private_key",
-                                  t,
-                                )}
-                              />
-                            )}
-                          </form.AppField>
-                        </>
-                      ) : (
-                        <>
-                          <form.AppField name="api_key">
-                            {(field) => (
-                              <field.PasswordField
-                                label={t("strategy.form.exchanges.apiKey")}
-                                placeholder={getPlaceholder(
-                                  exchangeId || "",
-                                  "api_key",
-                                  t,
-                                )}
-                              />
-                            )}
-                          </form.AppField>
-                          <form.AppField name="secret_key">
-                            {(field) => (
-                              <field.PasswordField
-                                label={t("strategy.form.exchanges.secretKey")}
-                                placeholder={getPlaceholder(
-                                  exchangeId || "",
-                                  "secret_key",
-                                  t,
-                                )}
-                              />
-                            )}
-                          </form.AppField>
-
-                          {(exchangeId === "okx" ||
-                            exchangeId === "coinbaseexchange") && (
-                            <form.AppField name="passphrase">
-                              {(field) => (
-                                <field.PasswordField
-                                  label={t(
-                                    "strategy.form.exchanges.passphrase",
-                                  )}
-                                  placeholder={getPlaceholder(
-                                    exchangeId || "",
-                                    "passphrase",
-                                    t,
-                                  )}
-                                />
-                              )}
-                            </form.AppField>
-                          )}
-                        </>
-                      );
-                    }}
-                  </form.Subscribe>
-
-                  <div className="-mt-2 flex flex-col gap-2">
-                    {testStatus && (
-                      <p
-                        className={`font-medium text-sm ${
-                          testStatus.success ? "text-green-600" : "text-red-600"
-                        }`}
-                      >
-                        {testStatus.message}
-                      </p>
-                    )}
-                    <Button
-                      variant="outline"
-                      className="w-full gap-2 py-4 font-medium text-base"
-                      onClick={handleTestConnection}
-                      disabled={isPending}
-                      type="button"
-                    >
-                      {isPending ? (
-                        <Spinner className="size-5 text-muted-foreground" />
-                      ) : (
-                        <Wallet className="size-5" />
-                      )}
-                      {t("strategy.form.exchanges.testConnection")}
-                    </Button>
-                  </div>
-                </>
-              )
-            );
-          }}
-        </form.Subscribe>
-      </FieldGroup>
-    );
+    return <ExchangeFormRender form={form} />;
   },
 });

--- a/frontend/src/components/valuecell/form/trading-strategy-form.tsx
+++ b/frontend/src/components/valuecell/form/trading-strategy-form.tsx
@@ -36,6 +36,263 @@ import { TRADING_SYMBOLS } from "@/constants/agent";
 import { withForm } from "@/hooks/use-form";
 import type { Strategy, StrategyPrompt } from "@/types/strategy";
 
+function TradingStrategyFormRender({
+  form,
+  prompts,
+  tradingMode,
+}: {
+  form: any;
+  prompts: StrategyPrompt[];
+  tradingMode: "live" | "virtual";
+}) {
+  const { t } = useTranslation();
+  const { mutateAsync: createStrategyPrompt } = useCreateStrategyPrompt();
+  const { mutate: deleteStrategyPrompt } = useDeleteStrategyPrompt();
+  const [deletePromptId, setDeletePromptId] = useState<string | null>(null);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  const handleDeletePrompt = (promptId: string) => {
+    setDeletePromptId(promptId);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const confirmDeletePrompt = () => {
+    if (deletePromptId) {
+      deleteStrategyPrompt(deletePromptId, {
+        onSuccess: () => {
+          if (form.state.values.template_id === deletePromptId) {
+            form.setFieldValue("template_id", "");
+          }
+          setIsDeleteDialogOpen(false);
+          setDeletePromptId(null);
+        },
+        onError: () => {
+          setIsDeleteDialogOpen(false);
+          setDeletePromptId(null);
+        },
+      });
+    }
+  };
+
+  const cancelDeletePrompt = () => {
+    setIsDeleteDialogOpen(false);
+    setDeletePromptId(null);
+  };
+
+  return (
+    <FieldGroup className="gap-6">
+      <form.AppField
+        listeners={{
+          onChange: ({ value }: { value: Strategy["strategy_type"] }) => {
+            if (value === "GridStrategy") {
+              form.setFieldValue("symbols", [TRADING_SYMBOLS[0]]);
+            } else {
+              form.setFieldValue("symbols", TRADING_SYMBOLS);
+            }
+          },
+        }}
+        name="strategy_type"
+      >
+        {(field: any) => (
+          <field.SelectField label={t("strategy.form.strategyType.label")}>
+            <SelectItem value="PromptBasedStrategy">
+              {t("strategy.form.strategyType.promptBased")}
+            </SelectItem>
+            <SelectItem value="GridStrategy">
+              {t("strategy.form.strategyType.grid")}
+            </SelectItem>
+          </field.SelectField>
+        )}
+      </form.AppField>
+
+      <form.AppField name="strategy_name">
+        {(field: any) => (
+          <field.TextField
+            label={t("strategy.form.strategyName.label")}
+            placeholder={t("strategy.form.strategyName.placeholder")}
+          />
+        )}
+      </form.AppField>
+
+      <FieldGroup className="flex flex-row gap-4">
+        {tradingMode === "virtual" && (
+          <form.AppField name="initial_capital">
+            {(field: any) => (
+              <field.NumberField
+                className="flex-1"
+                label={t("strategy.form.initialCapital.label")}
+                placeholder={t("strategy.form.initialCapital.placeholder")}
+              />
+            )}
+          </form.AppField>
+        )}
+
+        <form.AppField name="max_leverage">
+          {(field: any) => (
+            <field.NumberField
+              className="flex-1"
+              label={t("strategy.form.maxLeverage.label")}
+              placeholder={t("strategy.form.maxLeverage.placeholder")}
+            />
+          )}
+        </form.AppField>
+      </FieldGroup>
+
+      <form.AppField name="decide_interval">
+        {(field: any) => (
+          <field.NumberField
+            label={t("strategy.form.decideInterval.label")}
+            placeholder={t("strategy.form.decideInterval.placeholder")}
+          />
+        )}
+      </form.AppField>
+
+      <form.Subscribe selector={(state: any) => state.values.strategy_type}>
+        {(strategyType: any) => {
+          return (
+            <form.Field name="symbols">
+              {(field: any) => (
+                <Field>
+                  <FieldLabel className="font-medium text-base text-foreground">
+                    {t("strategy.form.tradingSymbols.label")}
+                  </FieldLabel>
+                  <MultiSelect
+                    maxSelected={
+                      strategyType === "GridStrategy" ? 1 : undefined
+                    }
+                    options={TRADING_SYMBOLS}
+                    value={field.state.value}
+                    onValueChange={(value) => field.handleChange(value)}
+                    placeholder={t("strategy.form.tradingSymbols.placeholder")}
+                    searchPlaceholder={t(
+                      "strategy.form.tradingSymbols.searchPlaceholder",
+                    )}
+                    emptyText={t("strategy.form.tradingSymbols.emptyText")}
+                    maxDisplayed={5}
+                    creatable
+                  />
+                  <FieldError errors={field.state.meta.errors} />
+                </Field>
+              )}
+            </form.Field>
+          );
+        }}
+      </form.Subscribe>
+
+      <form.Subscribe selector={(state: any) => state.values.strategy_type}>
+        {(strategyType: any) => {
+          return (
+            strategyType === "PromptBasedStrategy" && (
+              <form.Field name="template_id">
+                {(field: any) => (
+                  <Field>
+                    <FieldLabel className="font-medium text-base text-foreground">
+                      {t("strategy.form.promptTemplate.label")}
+                    </FieldLabel>
+                    <div className="flex items-center gap-3">
+                      <Select
+                        value={field.state.value}
+                        onValueChange={(value) => {
+                          field.handleChange(value);
+                        }}
+                      >
+                        <SelectTrigger className="flex-1">
+                          <SelectValue />
+                        </SelectTrigger>
+
+                        <SelectContent>
+                          {prompts.length > 0 &&
+                            prompts.map((prompt) => (
+                              <SelectItem
+                                key={prompt.id}
+                                value={prompt.id}
+                                className="relative hover:[&_button]:opacity-100 hover:[&_button]:transition-opacity"
+                              >
+                                <span>{prompt.name}</span>
+                                {field.state.value !== prompt.id && (
+                                  <button
+                                    type="button"
+                                    className="absolute right-2 z-50 flex size-3.5 items-center justify-center rounded-sm p-0 opacity-0 transition-all hover:bg-destructive/10 hover:text-destructive hover:opacity-100"
+                                    onPointerUp={(e) => {
+                                      e.stopPropagation();
+                                      e.preventDefault();
+                                      handleDeletePrompt(prompt.id);
+                                    }}
+                                  >
+                                    <Trash2 className="h-3 w-3" />
+                                  </button>
+                                )}
+                              </SelectItem>
+                            ))}
+                          <NewPromptModal
+                            onSave={async (value) => {
+                              const { data: prompt } =
+                                await createStrategyPrompt(value);
+                              form.setFieldValue("template_id", prompt.id);
+                            }}
+                          >
+                            <Button
+                              className="w-full"
+                              type="button"
+                              variant="outline"
+                            >
+                              <Plus />
+                              {t("strategy.form.promptTemplate.new")}
+                            </Button>
+                          </NewPromptModal>
+                        </SelectContent>
+                      </Select>
+
+                      <ViewStrategyModal
+                        prompt={prompts.find(
+                          (prompt) => prompt.id === field.state.value,
+                        )}
+                      >
+                        <Button type="button" variant="outline">
+                          <Eye />
+                          {t("strategy.form.promptTemplate.view")}
+                        </Button>
+                      </ViewStrategyModal>
+                    </div>
+                    <FieldError errors={field.state.meta.errors} />
+                  </Field>
+                )}
+              </form.Field>
+            )
+          );
+        }}
+      </form.Subscribe>
+
+      <AlertDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("strategy.prompt.delete.title")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("strategy.prompt.delete.description")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={cancelDeletePrompt}>
+              {t("strategy.action.cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmDeletePrompt}
+              className="bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20"
+            >
+              {t("strategy.action.confirmDelete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </FieldGroup>
+  );
+}
+
 export const TradingStrategyForm = withForm({
   defaultValues: {
     strategy_type: "" as Strategy["strategy_type"],
@@ -51,255 +308,12 @@ export const TradingStrategyForm = withForm({
     tradingMode: "live" as "live" | "virtual",
   },
   render({ form, prompts, tradingMode }) {
-    const { t } = useTranslation();
-    const { mutateAsync: createStrategyPrompt } = useCreateStrategyPrompt();
-    const { mutate: deleteStrategyPrompt } = useDeleteStrategyPrompt();
-    const [deletePromptId, setDeletePromptId] = useState<string | null>(null);
-    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-
-    const handleDeletePrompt = (promptId: string) => {
-      setDeletePromptId(promptId);
-      setIsDeleteDialogOpen(true);
-    };
-
-    const confirmDeletePrompt = () => {
-      if (deletePromptId) {
-        deleteStrategyPrompt(deletePromptId, {
-          onSuccess: () => {
-            // If the deleted prompt was currently selected, clear the selection
-            if (form.state.values.template_id === deletePromptId) {
-              form.setFieldValue("template_id", "");
-            }
-            setIsDeleteDialogOpen(false);
-            setDeletePromptId(null);
-          },
-          onError: () => {
-            setIsDeleteDialogOpen(false);
-            setDeletePromptId(null);
-          },
-        });
-      }
-    };
-
-    const cancelDeletePrompt = () => {
-      setIsDeleteDialogOpen(false);
-      setDeletePromptId(null);
-    };
-
     return (
-      <FieldGroup className="gap-6">
-        <form.AppField
-          listeners={{
-            onChange: ({ value }: { value: Strategy["strategy_type"] }) => {
-              if (value === "GridStrategy") {
-                form.setFieldValue("symbols", [TRADING_SYMBOLS[0]]);
-              } else {
-                form.setFieldValue("symbols", TRADING_SYMBOLS);
-              }
-            },
-          }}
-          name="strategy_type"
-        >
-          {(field) => (
-            <field.SelectField label={t("strategy.form.strategyType.label")}>
-              <SelectItem value="PromptBasedStrategy">
-                {t("strategy.form.strategyType.promptBased")}
-              </SelectItem>
-              <SelectItem value="GridStrategy">
-                {t("strategy.form.strategyType.grid")}
-              </SelectItem>
-            </field.SelectField>
-          )}
-        </form.AppField>
-
-        <form.AppField name="strategy_name">
-          {(field) => (
-            <field.TextField
-              label={t("strategy.form.strategyName.label")}
-              placeholder={t("strategy.form.strategyName.placeholder")}
-            />
-          )}
-        </form.AppField>
-
-        <FieldGroup className="flex flex-row gap-4">
-          {tradingMode === "virtual" && (
-            <form.AppField name="initial_capital">
-              {(field) => (
-                <field.NumberField
-                  className="flex-1"
-                  label={t("strategy.form.initialCapital.label")}
-                  placeholder={t("strategy.form.initialCapital.placeholder")}
-                />
-              )}
-            </form.AppField>
-          )}
-
-          <form.AppField name="max_leverage">
-            {(field) => (
-              <field.NumberField
-                className="flex-1"
-                label={t("strategy.form.maxLeverage.label")}
-                placeholder={t("strategy.form.maxLeverage.placeholder")}
-              />
-            )}
-          </form.AppField>
-        </FieldGroup>
-
-        <form.AppField name="decide_interval">
-          {(field) => (
-            <field.NumberField
-              label={t("strategy.form.decideInterval.label")}
-              placeholder={t("strategy.form.decideInterval.placeholder")}
-            />
-          )}
-        </form.AppField>
-
-        <form.Subscribe selector={(state) => state.values.strategy_type}>
-          {(strategyType) => {
-            return (
-              <form.Field name="symbols">
-                {(field) => (
-                  <Field>
-                    <FieldLabel className="font-medium text-base text-foreground">
-                      {t("strategy.form.tradingSymbols.label")}
-                    </FieldLabel>
-                    <MultiSelect
-                      maxSelected={
-                        strategyType === "GridStrategy" ? 1 : undefined
-                      }
-                      options={TRADING_SYMBOLS}
-                      value={field.state.value}
-                      onValueChange={(value) => field.handleChange(value)}
-                      placeholder={t(
-                        "strategy.form.tradingSymbols.placeholder",
-                      )}
-                      searchPlaceholder={t(
-                        "strategy.form.tradingSymbols.searchPlaceholder",
-                      )}
-                      emptyText={t("strategy.form.tradingSymbols.emptyText")}
-                      maxDisplayed={5}
-                      creatable
-                    />
-                    <FieldError errors={field.state.meta.errors} />
-                  </Field>
-                )}
-              </form.Field>
-            );
-          }}
-        </form.Subscribe>
-
-        <form.Subscribe selector={(state) => state.values.strategy_type}>
-          {(strategyType) => {
-            return (
-              strategyType === "PromptBasedStrategy" && (
-                <form.Field name="template_id">
-                  {(field) => (
-                    <Field>
-                      <FieldLabel className="font-medium text-base text-foreground">
-                        {t("strategy.form.promptTemplate.label")}
-                      </FieldLabel>
-                      <div className="flex items-center gap-3">
-                        <Select
-                          value={field.state.value}
-                          onValueChange={(value) => {
-                            field.handleChange(value);
-                          }}
-                        >
-                          <SelectTrigger className="flex-1">
-                            <SelectValue />
-                          </SelectTrigger>
-
-                          <SelectContent>
-                            {prompts.length > 0 &&
-                              prompts.map((prompt) => (
-                                <SelectItem
-                                  key={prompt.id}
-                                  value={prompt.id}
-                                  className="relative hover:[&_button]:opacity-100 hover:[&_button]:transition-opacity"
-                                >
-                                  <span>{prompt.name}</span>
-                                  {field.state.value !== prompt.id && (
-                                    <button
-                                      type="button"
-                                      className="absolute right-2 z-50 flex size-3.5 items-center justify-center rounded-sm p-0 opacity-0 transition-all hover:bg-destructive/10 hover:text-destructive hover:opacity-100"
-                                      onPointerUp={(e) => {
-                                        e.stopPropagation();
-                                        e.preventDefault();
-                                        handleDeletePrompt(prompt.id);
-                                      }}
-                                    >
-                                      <Trash2 className="h-3 w-3" />
-                                    </button>
-                                  )}
-                                </SelectItem>
-                              ))}
-                            <NewPromptModal
-                              onSave={async (value) => {
-                                const { data: prompt } =
-                                  await createStrategyPrompt(value);
-                                form.setFieldValue("template_id", prompt.id);
-                              }}
-                            >
-                              <Button
-                                className="w-full"
-                                type="button"
-                                variant="outline"
-                              >
-                                <Plus />
-                                {t("strategy.form.promptTemplate.new")}
-                              </Button>
-                            </NewPromptModal>
-                          </SelectContent>
-                        </Select>
-
-                        <ViewStrategyModal
-                          prompt={prompts.find(
-                            (prompt) => prompt.id === field.state.value,
-                          )}
-                        >
-                          <Button type="button" variant="outline">
-                            <Eye />
-                            {t("strategy.form.promptTemplate.view")}
-                          </Button>
-                        </ViewStrategyModal>
-                      </div>
-                      <FieldError errors={field.state.meta.errors} />
-                    </Field>
-                  )}
-                </form.Field>
-              )
-            );
-          }}
-        </form.Subscribe>
-
-        {/* Delete Confirmation Dialog */}
-        <AlertDialog
-          open={isDeleteDialogOpen}
-          onOpenChange={setIsDeleteDialogOpen}
-        >
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>
-                {t("strategy.prompt.delete.title")}
-              </AlertDialogTitle>
-              <AlertDialogDescription>
-                {t("strategy.prompt.delete.description")}
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel onClick={cancelDeletePrompt}>
-                {t("strategy.action.cancel")}
-              </AlertDialogCancel>
-              <AlertDialogAction
-                onClick={confirmDeletePrompt}
-                className="bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20"
-              >
-                {t("strategy.action.confirmDelete")}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      </FieldGroup>
+      <TradingStrategyFormRender
+        form={form}
+        prompts={prompts}
+        tradingMode={tradingMode}
+      />
     );
   },
 });

--- a/frontend/src/components/valuecell/menus/agent-menus.tsx
+++ b/frontend/src/components/valuecell/menus/agent-menus.tsx
@@ -153,10 +153,10 @@ function AgentMenuCard({
 
 export {
   AgentMenu,
-  AgentMenuContent,
-  AgentMenuSuffix,
-  AgentMenuIcon,
-  AgentMenuTitle,
-  AgentMenuDescription,
   AgentMenuCard,
+  AgentMenuContent,
+  AgentMenuDescription,
+  AgentMenuIcon,
+  AgentMenuSuffix,
+  AgentMenuTitle,
 };

--- a/frontend/src/components/valuecell/menus/stock-menus.tsx
+++ b/frontend/src/components/valuecell/menus/stock-menus.tsx
@@ -139,8 +139,8 @@ function StockMenuListItem({
 
 export {
   StockMenu,
-  StockMenuHeader,
   StockMenuGroup,
   StockMenuGroupHeader,
+  StockMenuHeader,
   StockMenuListItem,
 };

--- a/frontend/src/components/valuecell/skeleton/agent-market-skeleton.tsx
+++ b/frontend/src/components/valuecell/skeleton/agent-market-skeleton.tsx
@@ -76,4 +76,4 @@ function AgentMarketSkeleton({
   );
 }
 
-export { AgentMarketSkeleton, AgentCardSkeleton };
+export { AgentCardSkeleton, AgentMarketSkeleton };

--- a/frontend/src/components/valuecell/skeleton/sparkline-stock-list-skeleton.tsx
+++ b/frontend/src/components/valuecell/skeleton/sparkline-stock-list-skeleton.tsx
@@ -71,4 +71,4 @@ function SparklineStockListSkeleton({
   );
 }
 
-export { SparklineStockListSkeleton, SparklineStockItemSkeleton };
+export { SparklineStockItemSkeleton, SparklineStockListSkeleton };

--- a/frontend/src/lib/sse-client.test.ts
+++ b/frontend/src/lib/sse-client.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import SSEClient, { SSEReadyState } from "./sse-client";
+
+describe("SSEClient", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    mock.restore();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("aggregates fragmented SSE chunks and emits parsed payloads in order", async () => {
+    const encoder = new TextEncoder();
+    const states: SSEReadyState[] = [];
+    const payloads: unknown[] = [];
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"type":"chunk","content":"hel'));
+        controller.enqueue(encoder.encode('lo"}\n\n'));
+        controller.enqueue(encoder.encode('data: {"type":"done","content":"ok"}\n\n'));
+        controller.close();
+      },
+    });
+
+    globalThis.fetch = mock(async () => {
+      return new Response(stream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as typeof fetch;
+
+    await new Promise<void>((resolve, reject) => {
+      const client = new SSEClient(
+        { url: "http://localhost/stream", timeout: 1000 },
+        {
+          onData: (data) => payloads.push(data),
+          onError: reject,
+          onStateChange: (state) => states.push(state),
+          onClose: () => resolve(),
+        },
+      );
+
+      void client.connect(JSON.stringify({ message: "ping" }));
+    });
+
+    expect(states).toEqual([
+      SSEReadyState.CONNECTING,
+      SSEReadyState.OPEN,
+      SSEReadyState.CLOSED,
+    ]);
+    expect(payloads).toEqual([
+      { type: "chunk", content: "hello" },
+      { type: "done", content: "ok" },
+    ]);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://localhost/stream",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ message: "ping" }),
+      }),
+    );
+  });
+
+  test("reports handshake timeout as an error and closes the stream", async () => {
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
+
+    const states: SSEReadyState[] = [];
+
+    const error = await new Promise<Error>((resolve) => {
+      const client = new SSEClient(
+        { url: "http://localhost/timeout", timeout: 10 },
+        {
+          onStateChange: (state) => states.push(state),
+          onError: resolve,
+        },
+      );
+
+      void client.connect();
+    });
+
+    expect(error.message).toBe("Handshake timeout");
+    expect(states).toEqual([
+      SSEReadyState.CONNECTING,
+      SSEReadyState.CLOSED,
+    ]);
+  });
+});

--- a/frontend/src/lib/sse-client.test.ts
+++ b/frontend/src/lib/sse-client.test.ts
@@ -19,9 +19,13 @@ describe("SSEClient", () => {
 
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
-        controller.enqueue(encoder.encode('data: {"type":"chunk","content":"hel'));
+        controller.enqueue(
+          encoder.encode('data: {"type":"chunk","content":"hel'),
+        );
         controller.enqueue(encoder.encode('lo"}\n\n'));
-        controller.enqueue(encoder.encode('data: {"type":"done","content":"ok"}\n\n'));
+        controller.enqueue(
+          encoder.encode('data: {"type":"done","content":"ok"}\n\n'),
+        );
         controller.close();
       },
     });
@@ -91,9 +95,6 @@ describe("SSEClient", () => {
     });
 
     expect(error.message).toBe("Handshake timeout");
-    expect(states).toEqual([
-      SSEReadyState.CONNECTING,
-      SSEReadyState.CLOSED,
-    ]);
+    expect(states).toEqual([SSEReadyState.CONNECTING, SSEReadyState.CLOSED]);
   });
 });

--- a/frontend/src/lib/tracker.ts
+++ b/frontend/src/lib/tracker.ts
@@ -119,4 +119,4 @@ export const withTrack = <T extends keyof TrackingEvents>(
   };
 };
 
-export { tracker, type TrackerConfig, type TrackingParams };
+export { type TrackerConfig, type TrackingParams, tracker };

--- a/frontend/src/store/plugin/tauri-store-state.test.ts
+++ b/frontend/src/store/plugin/tauri-store-state.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let isTauriValue = false;
+let loadCalls: string[] = [];
+let saveCalls = 0;
+let setCalls: Array<{ key: string; value: string }> = [];
+let deleteCalls: string[] = [];
+let storeValues = new Map<string, string>();
+
+mock.module("@tauri-apps/api/core", () => ({
+  isTauri: () => isTauriValue,
+}));
+
+mock.module("@tauri-apps/plugin-store", () => ({
+  load: async (storeName: string) => {
+    loadCalls.push(storeName);
+    return {
+      get: async (key: string) => storeValues.get(key) ?? null,
+      set: async (key: string, value: string) => {
+        setCalls.push({ key, value });
+        storeValues.set(key, value);
+      },
+      delete: async (key: string) => {
+        deleteCalls.push(key);
+        storeValues.delete(key);
+      },
+      save: async () => {
+        saveCalls += 1;
+      },
+    };
+  },
+}));
+
+const { TauriStoreState } = await import("./tauri-store-state");
+
+describe("TauriStoreState", () => {
+  beforeEach(() => {
+    isTauriValue = false;
+    loadCalls = [];
+    saveCalls = 0;
+    setCalls = [];
+    deleteCalls = [];
+    storeValues = new Map<string, string>();
+    Object.defineProperty(globalThis, "window", {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  test("falls back to inert storage outside Tauri", async () => {
+    const storage = new TauriStoreState("valuecell-settings.json");
+
+    await storage.init();
+    await storage.setItem("foo", "bar");
+    await storage.removeItem("foo");
+
+    expect(loadCalls).toEqual([]);
+    await expect(storage.getItem("foo")).resolves.toBeNull();
+  });
+
+  test("loads the Tauri store and debounces save operations", async () => {
+    isTauriValue = true;
+    const storage = new TauriStoreState("valuecell-settings.json");
+
+    await storage.init();
+    await storage.setItem("theme", '{"dark":true}');
+    await storage.setItem("language", '"zh_CN"');
+    await storage.removeItem("theme");
+
+    expect(loadCalls).toEqual(["valuecell-settings.json"]);
+    expect(setCalls).toEqual([
+      { key: "theme", value: '{"dark":true}' },
+      { key: "language", value: '"zh_CN"' },
+    ]);
+    expect(deleteCalls).toEqual(["theme"]);
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    expect(saveCalls).toBe(1);
+    await expect(storage.getItem("language")).resolves.toBe('"zh_CN"');
+    await expect(storage.getItem("theme")).resolves.toBeNull();
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -43,6 +43,10 @@
     "src",
     ".react-router/types/**/*"
   ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts"
+  ],
   "references": [
     {
       "path": "./tsconfig.node.json"


### PR DESCRIPTION
## Summary
- add a thin frontend behavior-test lane for issue #19
- cover one streaming path and one persistence path without introducing a heavier React component test stack yet
- wire the new behavior tests into the existing frontend GitHub Actions workflow

## What changed
- add `frontend/src/lib/sse-client.test.ts`
  - verifies fragmented SSE chunks are buffered and parsed in order
  - verifies handshake timeout is surfaced as an error instead of hanging silently
- add `frontend/src/store/plugin/tauri-store-state.test.ts`
  - verifies non-Tauri fallback stays inert
  - verifies Tauri store writes are persisted with debounced save behavior
- add `bun run test` script in `frontend/package.json`
- add a dedicated `test` job to `.github/workflows/frontend.yml`
- exclude `*.test.ts` / `*.spec.ts` from the app `tsc` include set so the new bun test files do not leak into the app typecheck lane

## Validation
- `cd frontend && bun test`
- `cd frontend && bun run typecheck`
- `cd frontend && bun run build`

## Notes
- This is intentionally a thin slice toward issue #19, not full closure.
- It covers behavior below the UI layer first, so we get stable regression protection for streaming and persistence without immediately taking on jsdom / React renderer test setup.
