### PR TITLE
test: add settings migration coverage for issue 19

### DIFF
--- a/frontend/src/store/settings-store.migrate.ts
+++ b/frontend/src/store/settings-store.migrate.ts
@@ -1,0 +1,58 @@
+import type { LanguageCode, StockColorMode } from "./settings-store.types";
+
+export const DEFAULT_LANGUAGE = "en";
+export const SETTINGS_STORE_VERSION = 1;
+export const DEFAULT_STOCK_COLOR_MODE: StockColorMode = "GREEN_UP_RED_DOWN";
+
+export const normalizeLanguageCode = (language: unknown): LanguageCode => {
+  const map: Record<string, LanguageCode> = {
+    en: "en",
+    ja: "ja",
+    "ja-JP": "ja",
+    zh_CN: "zh_CN",
+    "zh-CN": "zh_CN",
+    "zh-Hans": "zh_CN",
+    zh_TW: "zh_TW",
+    "zh-TW": "zh_TW",
+    "zh-Hant": "zh_TW",
+  };
+
+  return typeof language === "string"
+    ? (map[language] ?? DEFAULT_LANGUAGE)
+    : DEFAULT_LANGUAGE;
+};
+
+export const normalizeStockColorMode = (mode: unknown): StockColorMode => {
+  return mode === "RED_UP_GREEN_DOWN"
+    ? "RED_UP_GREEN_DOWN"
+    : DEFAULT_STOCK_COLOR_MODE;
+};
+
+export const migrateSettingsPersistedState = (
+  persistedState:
+    | Partial<
+        Pick<
+          {
+            stockColorMode: StockColorMode;
+            language: LanguageCode;
+          },
+          "stockColorMode" | "language"
+        >
+      >
+    | undefined,
+  version: number,
+) => {
+  if (version >= SETTINGS_STORE_VERSION) {
+    return (
+      persistedState ?? {
+        stockColorMode: DEFAULT_STOCK_COLOR_MODE,
+        language: DEFAULT_LANGUAGE as LanguageCode,
+      }
+    );
+  }
+
+  return {
+    stockColorMode: normalizeStockColorMode(persistedState?.stockColorMode),
+    language: normalizeLanguageCode(persistedState?.language),
+  };
+};

--- a/frontend/src/store/settings-store.test.ts
+++ b/frontend/src/store/settings-store.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_LANGUAGE,
+  migrateSettingsPersistedState,
+} from "./settings-store.migrate";
+import type { StockColorMode } from "./settings-store.types";
+
+describe("migrateSettingsPersistedState", () => {
+  test("normalizes legacy language codes and preserves valid color mode", () => {
+    const migrated = migrateSettingsPersistedState(
+      {
+        stockColorMode: "RED_UP_GREEN_DOWN",
+        language: "zh-Hans",
+      },
+      0,
+    );
+
+    expect(migrated).toEqual({
+      stockColorMode: "RED_UP_GREEN_DOWN",
+      language: "zh_CN",
+    });
+  });
+
+  test("fills missing fields with defaults for older persisted snapshots", () => {
+    const migrated = migrateSettingsPersistedState(
+      {
+        language: "ja-JP",
+      },
+      0,
+    );
+
+    expect(migrated).toEqual({
+      stockColorMode: "GREEN_UP_RED_DOWN",
+      language: "ja",
+    });
+  });
+
+  test("falls back unknown legacy values to defaults", () => {
+    const migrated = migrateSettingsPersistedState(
+      {
+        stockColorMode: "BLUE_UP_PURPLE_DOWN",
+        language: "fr",
+      },
+      0,
+    );
+
+    expect(migrated).toEqual({
+      stockColorMode: "GREEN_UP_RED_DOWN",
+      language: DEFAULT_LANGUAGE,
+    });
+  });
+
+  test("keeps current persisted values stable on newer versions", () => {
+    const current = {
+      stockColorMode: "GREEN_UP_RED_DOWN" as StockColorMode,
+      language: "zh_TW",
+    };
+
+    expect(migrateSettingsPersistedState(current, 1)).toEqual(current);
+  });
+});

--- a/frontend/src/store/settings-store.ts
+++ b/frontend/src/store/settings-store.ts
@@ -14,10 +14,15 @@ import {
 } from "@/constants/stock";
 import i18n from "@/i18n";
 import type { StockChangeType } from "@/types/stock";
+import {
+  DEFAULT_LANGUAGE,
+  migrateSettingsPersistedState,
+  SETTINGS_STORE_VERSION,
+} from "./settings-store.migrate";
+import type { LanguageCode, StockColorMode } from "./settings-store.types";
 
-export type StockColorMode = "GREEN_UP_RED_DOWN" | "RED_UP_GREEN_DOWN";
-export type LanguageCode = "en" | "zh_CN" | "zh_TW" | "ja";
-export const DEFAULT_LANGUAGE = "en";
+export type { LanguageCode, StockColorMode };
+export { DEFAULT_LANGUAGE };
 
 interface SettingsStoreState {
   stockColorMode: StockColorMode;

--- a/frontend/src/store/settings-store.types.ts
+++ b/frontend/src/store/settings-store.types.ts
@@ -1,0 +1,2 @@
+export type StockColorMode = "GREEN_UP_RED_DOWN" | "RED_UP_GREEN_DOWN";
+export type LanguageCode = "en" | "zh_CN" | "zh_TW" | "ja";


### PR DESCRIPTION
## Summary
- add explicit settings persistence migration coverage for issue #19
- version the settings store so older persisted snapshots are normalized instead of being trusted blindly
- keep this slice at the store/migration layer without introducing heavier UI/component test setup

## What changed
- add `frontend/src/store/settings-store.migrate.ts`
  - centralizes settings persistence migration helpers
  - normalizes legacy language codes (`zh-Hans`, `zh-Hant`, `ja-JP`, etc.)
  - falls back invalid or missing values to safe defaults
- add `frontend/src/store/settings-store.types.ts`
  - extracts reusable settings types from the store module
- update `frontend/src/store/settings-store.ts`
  - add `version` + `migrate` to the persisted settings store
  - reuse the extracted migration helpers/types
- add `frontend/src/store/settings-store.test.ts`
  - covers legacy language normalization
  - covers missing-field backfill
  - covers invalid legacy value fallback
  - covers current-version stability

## Validation
- `cd frontend && bun test src/store/settings-store.test.ts`
- `cd frontend && bun run typecheck`
- `cd frontend && bunx @biomejs/biome@2.4.12 ci --diagnostic-level=error ./src`

## Notes
- This is another thin slice toward issue #19, not full closure.
- It specifically addresses the "settings store / local persistence migration" risk called out in the issue.
