### PR TITLE
test: wire settings schema migration safeguards for issue 23

### DIFF
--- a/frontend/src/store/settings-store.migrate.ts
+++ b/frontend/src/store/settings-store.migrate.ts
@@ -41,14 +41,15 @@ export const migrateSettingsPersistedState = (
       >
     | undefined,
   version: number,
-) => {
+): {
+  stockColorMode: StockColorMode;
+  language: LanguageCode;
+} => {
   if (version >= SETTINGS_STORE_VERSION) {
-    return (
-      persistedState ?? {
-        stockColorMode: DEFAULT_STOCK_COLOR_MODE,
-        language: DEFAULT_LANGUAGE as LanguageCode,
-      }
-    );
+    return {
+      stockColorMode: normalizeStockColorMode(persistedState?.stockColorMode),
+      language: normalizeLanguageCode(persistedState?.language),
+    };
   }
 
   return {

--- a/frontend/src/store/settings-store.persist.test.ts
+++ b/frontend/src/store/settings-store.persist.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
-  settingsStorePersistOptions,
   SETTINGS_STORE_NAME,
+  settingsStorePersistOptions,
 } from "./settings-store.persist";
 
 describe("settingsStorePersistOptions", () => {

--- a/frontend/src/store/settings-store.persist.test.ts
+++ b/frontend/src/store/settings-store.persist.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+  settingsStorePersistOptions,
+  SETTINGS_STORE_NAME,
+} from "./settings-store.persist";
+
+describe("settingsStorePersistOptions", () => {
+  test("wires schema versioned migration metadata", () => {
+    expect(settingsStorePersistOptions.name).toBe(SETTINGS_STORE_NAME);
+    expect(settingsStorePersistOptions.version).toBe(1);
+    expect(typeof settingsStorePersistOptions.migrate).toBe("function");
+  });
+
+  test("normalizes legacy snapshots through persist migrate", async () => {
+    const migrated = await settingsStorePersistOptions.migrate?.(
+      {
+        stockColorMode: "RED_UP_GREEN_DOWN",
+        language: "zh-Hans",
+      },
+      0,
+    );
+
+    expect(migrated).toEqual({
+      stockColorMode: "RED_UP_GREEN_DOWN",
+      language: "zh_CN",
+    });
+  });
+});

--- a/frontend/src/store/settings-store.persist.ts
+++ b/frontend/src/store/settings-store.persist.ts
@@ -1,0 +1,26 @@
+import type { PersistOptions } from "zustand/middleware";
+import {
+  migrateSettingsPersistedState,
+  SETTINGS_STORE_VERSION,
+} from "./settings-store.migrate";
+import type { LanguageCode, StockColorMode } from "./settings-store.types";
+
+export interface SettingsStorePersistedState {
+  stockColorMode: StockColorMode;
+  language: LanguageCode;
+}
+
+export const SETTINGS_STORE_NAME = "valuecell-settings";
+
+export const settingsStorePersistOptions: Pick<
+  PersistOptions<SettingsStorePersistedState>,
+  "name" | "version" | "migrate"
+> = {
+  name: SETTINGS_STORE_NAME,
+  version: SETTINGS_STORE_VERSION,
+  migrate: (persistedState, version) =>
+    migrateSettingsPersistedState(
+      persistedState as Partial<SettingsStorePersistedState>,
+      version,
+    ),
+};

--- a/frontend/src/store/settings-store.test.ts
+++ b/frontend/src/store/settings-store.test.ts
@@ -58,4 +58,11 @@ describe("migrateSettingsPersistedState", () => {
 
     expect(migrateSettingsPersistedState(current, 1)).toEqual(current);
   });
+
+  test("sanitizes missing current-version fields to safe defaults", () => {
+    expect(migrateSettingsPersistedState(undefined, 1)).toEqual({
+      stockColorMode: "GREEN_UP_RED_DOWN",
+      language: DEFAULT_LANGUAGE,
+    });
+  });
 });

--- a/frontend/src/store/settings-store.ts
+++ b/frontend/src/store/settings-store.ts
@@ -14,11 +14,8 @@ import {
 } from "@/constants/stock";
 import i18n from "@/i18n";
 import type { StockChangeType } from "@/types/stock";
-import {
-  DEFAULT_LANGUAGE,
-  migrateSettingsPersistedState,
-  SETTINGS_STORE_VERSION,
-} from "./settings-store.migrate";
+import { DEFAULT_LANGUAGE } from "./settings-store.migrate";
+import { settingsStorePersistOptions } from "./settings-store.persist";
 import type { LanguageCode, StockColorMode } from "./settings-store.types";
 
 export type { LanguageCode, StockColorMode };
@@ -62,9 +59,7 @@ export const useSettingsStore = create<SettingsStoreState>()(
           i18n.changeLanguage(language);
         },
       }),
-      {
-        name: "valuecell-settings",
-      },
+      settingsStorePersistOptions,
     ),
     { name: "SettingsStore", enabled: import.meta.env.DEV },
   ),


### PR DESCRIPTION
## Summary
- wire the settings Zustand persist config to use explicit schema version + migrate metadata
- extract persist options into a pure module so the wiring can be regression-tested without the existing i18n/store cycle
- sanitize current-version persisted snapshots to safe defaults when fields are missing or invalid

## Testing
- cd frontend && bun test src/store/settings-store.test.ts src/store/settings-store.persist.test.ts
- cd frontend && bun run typecheck

Toward #23
