### PR TITLE
test: add system store schema migration safeguards for issue 23

### DIFF
--- a/frontend/src/store/system-store.persist.test.ts
+++ b/frontend/src/store/system-store.persist.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
   INITIAL_SYSTEM_INFO,
+  migrateSystemPersistedState,
   SYSTEM_STORE_NAME,
   SYSTEM_STORE_VERSION,
-  migrateSystemPersistedState,
   systemStorePersistOptions,
 } from "./system-store.persist";
 

--- a/frontend/src/store/system-store.persist.test.ts
+++ b/frontend/src/store/system-store.persist.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+  INITIAL_SYSTEM_INFO,
+  SYSTEM_STORE_NAME,
+  SYSTEM_STORE_VERSION,
+  migrateSystemPersistedState,
+  systemStorePersistOptions,
+} from "./system-store.persist";
+
+describe("systemStorePersistOptions", () => {
+  test("wires schema versioned migration metadata", () => {
+    expect(systemStorePersistOptions.name).toBe(SYSTEM_STORE_NAME);
+    expect(systemStorePersistOptions.version).toBe(SYSTEM_STORE_VERSION);
+    expect(typeof systemStorePersistOptions.migrate).toBe("function");
+  });
+
+  test("sanitizes legacy persisted snapshots through persist migrate", async () => {
+    const migrated = await systemStorePersistOptions.migrate?.(
+      {
+        access_token: "token",
+        refresh_token: 123,
+        id: "user-1",
+        email: null,
+        name: "Asata",
+      },
+      0,
+    );
+
+    expect(migrated).toEqual({
+      ...INITIAL_SYSTEM_INFO,
+      access_token: "token",
+      id: "user-1",
+      name: "Asata",
+    });
+  });
+});
+
+describe("migrateSystemPersistedState", () => {
+  test("fills missing fields with safe defaults", () => {
+    expect(migrateSystemPersistedState(undefined)).toEqual(INITIAL_SYSTEM_INFO);
+  });
+
+  test("keeps valid current snapshot values stable", () => {
+    const current = {
+      ...INITIAL_SYSTEM_INFO,
+      access_token: "access",
+      refresh_token: "refresh",
+      id: "42",
+      email: "user@example.com",
+      name: "ValueCell",
+      avatar: "https://example.com/avatar.png",
+      created_at: "2026-04-20T08:00:00Z",
+      updated_at: "2026-04-20T08:05:00Z",
+    };
+
+    expect(migrateSystemPersistedState(current)).toEqual(current);
+  });
+});

--- a/frontend/src/store/system-store.persist.ts
+++ b/frontend/src/store/system-store.persist.ts
@@ -1,0 +1,46 @@
+import type { PersistOptions } from "zustand/middleware";
+import type { SystemInfo } from "@/types/system";
+
+export const SYSTEM_STORE_NAME = "valuecell-system-store";
+export const SYSTEM_STORE_VERSION = 1;
+
+export type SystemStorePersistedState = SystemInfo;
+
+export const INITIAL_SYSTEM_INFO: SystemStorePersistedState = {
+  access_token: "",
+  refresh_token: "",
+  id: "",
+  email: "",
+  name: "",
+  avatar: "",
+  created_at: "",
+  updated_at: "",
+};
+
+const normalizeStringField = (value: unknown): string =>
+  typeof value === "string" ? value : "";
+
+export const migrateSystemPersistedState = (
+  persistedState: Partial<SystemStorePersistedState> | undefined,
+): SystemStorePersistedState => ({
+  access_token: normalizeStringField(persistedState?.access_token),
+  refresh_token: normalizeStringField(persistedState?.refresh_token),
+  id: normalizeStringField(persistedState?.id),
+  email: normalizeStringField(persistedState?.email),
+  name: normalizeStringField(persistedState?.name),
+  avatar: normalizeStringField(persistedState?.avatar),
+  created_at: normalizeStringField(persistedState?.created_at),
+  updated_at: normalizeStringField(persistedState?.updated_at),
+});
+
+export const systemStorePersistOptions: Pick<
+  PersistOptions<SystemStorePersistedState>,
+  "name" | "version" | "migrate"
+> = {
+  name: SYSTEM_STORE_NAME,
+  version: SYSTEM_STORE_VERSION,
+  migrate: (persistedState) =>
+    migrateSystemPersistedState(
+      persistedState as Partial<SystemStorePersistedState> | undefined,
+    ),
+};

--- a/frontend/src/store/system-store.ts
+++ b/frontend/src/store/system-store.ts
@@ -3,26 +3,18 @@ import { createJSONStorage, devtools, persist } from "zustand/middleware";
 import { useShallow } from "zustand/shallow";
 import type { SystemInfo } from "@/types/system";
 import { TauriStoreState } from "./plugin/tauri-store-state";
-
-const STORAGE_KEY = "valuecell-system-store";
+import {
+  INITIAL_SYSTEM_INFO,
+  SYSTEM_STORE_NAME,
+  systemStorePersistOptions,
+} from "./system-store.persist";
 
 interface SystemStoreState extends SystemInfo {
   setSystemInfo: (info: Partial<SystemInfo>) => void;
   clearSystemInfo: () => void;
 }
 
-const INITIAL_SYSTEM_INFO: SystemInfo = {
-  access_token: "",
-  refresh_token: "",
-  id: "",
-  email: "",
-  name: "",
-  avatar: "",
-  created_at: "",
-  updated_at: "",
-};
-
-const store = new TauriStoreState(STORAGE_KEY);
+const store = new TauriStoreState(SYSTEM_STORE_NAME);
 await store.init();
 
 export const useSystemStore = create<SystemStoreState>()(
@@ -34,7 +26,7 @@ export const useSystemStore = create<SystemStoreState>()(
         clearSystemInfo: () => set(INITIAL_SYSTEM_INFO),
       }),
       {
-        name: STORAGE_KEY,
+        ...systemStorePersistOptions,
         storage: createJSONStorage(() => store),
       },
     ),


### PR DESCRIPTION
## Summary
- add explicit schema version + migrate wiring for the persisted system store
- extract system store persist metadata into a pure module so migration behavior can be regression-tested cleanly
- sanitize missing or invalid persisted system fields back to safe string defaults

## Testing
- cd frontend && bun test src/store/system-store.persist.test.ts
- cd frontend && bun run typecheck

Toward #23
