### PR TITLE
test: harden upgrade compatibility regressions

### DIFF
--- a/frontend/src/api/system.test.ts
+++ b/frontend/src/api/system.test.ts
@@ -58,4 +58,26 @@ describe("normalizeConfigHealth", () => {
       ],
     });
   });
+
+  test("drops issue entries that are missing required shape", () => {
+    expect(
+      normalizeConfigHealth({
+        status: "error",
+        primary_provider: "openai",
+        enabled_providers: ["openai"],
+        issues: [
+          {
+            scope: "provider:openai",
+            message: "Missing OPENAI_API_KEY",
+          },
+          "bad-entry",
+        ],
+      }),
+    ).toEqual({
+      status: "error",
+      primary_provider: "openai",
+      enabled_providers: ["openai"],
+      issues: [],
+    });
+  });
 });

--- a/frontend/src/store/settings-store.persist.test.ts
+++ b/frontend/src/store/settings-store.persist.test.ts
@@ -25,4 +25,19 @@ describe("settingsStorePersistOptions", () => {
       language: "zh_CN",
     });
   });
+
+  test("sanitizes malformed current-version snapshots through persist migrate", async () => {
+    const migrated = await settingsStorePersistOptions.migrate?.(
+      {
+        stockColorMode: "BLUE_UP_PURPLE_DOWN",
+        language: 42,
+      },
+      1,
+    );
+
+    expect(migrated).toEqual({
+      stockColorMode: "GREEN_UP_RED_DOWN",
+      language: "en",
+    });
+  });
 });

--- a/frontend/src/store/system-store.persist.test.ts
+++ b/frontend/src/store/system-store.persist.test.ts
@@ -33,6 +33,30 @@ describe("systemStorePersistOptions", () => {
       name: "Asata",
     });
   });
+
+  test("sanitizes malformed current-version snapshots through persist migrate", async () => {
+    const migrated = await systemStorePersistOptions.migrate?.(
+      {
+        access_token: ["token"],
+        refresh_token: "refresh",
+        id: "user-1",
+        email: 123,
+        name: "Asata",
+        avatar: { url: "https://example.com/avatar.png" },
+        created_at: null,
+        updated_at: "2026-04-20T08:05:00Z",
+      },
+      1,
+    );
+
+    expect(migrated).toEqual({
+      ...INITIAL_SYSTEM_INFO,
+      refresh_token: "refresh",
+      id: "user-1",
+      name: "Asata",
+      updated_at: "2026-04-20T08:05:00Z",
+    });
+  });
 });
 
 describe("migrateSystemPersistedState", () => {

--- a/python/valuecell/config/tests/test_config_health.py
+++ b/python/valuecell/config/tests/test_config_health.py
@@ -62,3 +62,54 @@ default_model: gpt-5
     assert report.primary_provider == "openai"
     assert report.enabled_providers == ["openai"]
     assert report.issues == []
+
+
+def test_config_health_adds_provider_inventory_warning_when_primary_credentials_are_missing(
+    tmp_path: Path,
+) -> None:
+    _write_base_config(tmp_path, primary_provider="openai")
+    _write(
+        tmp_path / "providers" / "openai.yaml",
+        """
+connection:
+  api_key_env: OPENAI_API_KEY
+default_model: gpt-5
+""",
+    )
+
+    report = ConfigManager(loader=ConfigLoader(config_dir=tmp_path)).get_config_health()
+
+    assert report.status == "error"
+    assert report.primary_provider == "openai"
+    assert report.enabled_providers == []
+    assert len(report.issues) == 2
+    assert report.issues[0].level == "error"
+    assert report.issues[0].scope == "provider:openai"
+    assert "OPENAI_API_KEY" in report.issues[0].message
+    assert report.issues[1].level == "warning"
+    assert report.issues[1].scope == "providers"
+    assert (
+        report.issues[1].message
+        == "No enabled providers with valid credentials were detected."
+    )
+
+
+def test_config_health_reports_missing_primary_provider_config_as_error(
+    tmp_path: Path,
+) -> None:
+    _write_base_config(tmp_path, primary_provider="openai")
+
+    report = ConfigManager(loader=ConfigLoader(config_dir=tmp_path)).get_config_health()
+
+    assert report.status == "error"
+    assert report.primary_provider == "openai"
+    assert report.enabled_providers == []
+    assert report.issues[0].level == "error"
+    assert report.issues[0].scope == "provider:openai"
+    assert "not found in configuration" in report.issues[0].message
+    assert report.issues[1].level == "warning"
+    assert report.issues[1].scope == "providers"
+    assert (
+        report.issues[1].message
+        == "No enabled providers with valid credentials were detected."
+    )


### PR DESCRIPTION
## Summary\n- add frontend persist regression coverage for malformed current-version snapshots\n- harden config-health normalization coverage for malformed issue payloads\n- extend backend config-health regression coverage for missing credentials and missing primary provider config\n\n## Testing\n- python/.venv/bin/pytest python/valuecell/config/tests/test_config_health.py\n- bun test ./src/store/settings-store.persist.test.ts ./src/store/system-store.persist.test.ts ./src/api/system.test.ts\n- bun run typecheck\n- bunx @biomejs/biome@2.4.12 check ./src/api/system.test.ts ./src/store/settings-store.persist.test.ts ./src/store/system-store.persist.test.ts\n\nRefs #43