### PR TITLE
feat: surface config health in settings

### DIFF
--- a/frontend/src/api/system.test.ts
+++ b/frontend/src/api/system.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeConfigHealth } from "./system";
+import { getVisibleConfigHealthIssues, normalizeConfigHealth } from "./system";
 
 describe("normalizeConfigHealth", () => {
   test("keeps valid config health payload stable", () => {
@@ -79,5 +79,53 @@ describe("normalizeConfigHealth", () => {
       enabled_providers: ["openai"],
       issues: [],
     });
+  });
+});
+
+describe("getVisibleConfigHealthIssues", () => {
+  test("returns no issues for healthy config health", () => {
+    expect(
+      getVisibleConfigHealthIssues({
+        status: "healthy",
+        primary_provider: "openai",
+        enabled_providers: ["openai"],
+        issues: [
+          {
+            level: "warning",
+            scope: "provider:openai",
+            message: "Missing OPENAI_API_KEY",
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  test("keeps only actionable warning or error messages", () => {
+    expect(
+      getVisibleConfigHealthIssues({
+        status: "warning",
+        primary_provider: "openai",
+        enabled_providers: [],
+        issues: [
+          {
+            level: "warning",
+            scope: "providers",
+            message:
+              "No enabled providers with valid credentials were detected.",
+          },
+          {
+            level: "error",
+            scope: "provider:openai",
+            message: "",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        level: "warning",
+        scope: "providers",
+        message: "No enabled providers with valid credentials were detected.",
+      },
+    ]);
   });
 });

--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -59,6 +59,29 @@ export const normalizeConfigHealth = (value: unknown): ConfigHealth => {
   };
 };
 
+export const getVisibleConfigHealthIssues = (
+  configHealth: ConfigHealth | null | undefined,
+) => {
+  if (!configHealth || configHealth.status === "healthy") {
+    return [];
+  }
+
+  return configHealth.issues.filter((issue) => issue.message.trim().length > 0);
+};
+
+export const useConfigHealth = () => {
+  return useQuery({
+    queryKey: API_QUERY_KEYS.SYSTEM.configHealth,
+    queryFn: () =>
+      apiClient.get<ApiResponse<ConfigHealth>>(
+        `${VALUECELL_BACKEND_URL}/system/config-health`,
+      ),
+    select: (data) => normalizeConfigHealth(data.data),
+    retry: false,
+    staleTime: 30_000,
+  });
+};
+
 export const useBackendHealth = () => {
   return useQuery({
     queryKey: ["backend-health"],

--- a/frontend/src/app/setting/_layout.tsx
+++ b/frontend/src/app/setting/_layout.tsx
@@ -9,6 +9,7 @@ import {
   ItemTitle,
 } from "@/components/ui/item";
 import { cn } from "@/lib/utils";
+import { ConfigHealthBanner } from "./components/config-health-banner";
 
 export default function SettingLayout() {
   const { t } = useTranslation();
@@ -75,8 +76,11 @@ export default function SettingLayout() {
       </aside>
 
       {/* Right content area */}
-      <main className="flex flex-1 overflow-hidden rounded-tr-xl rounded-br-xl bg-card">
-        <Outlet />
+      <main className="flex flex-1 flex-col gap-4 overflow-hidden rounded-tr-xl rounded-br-xl bg-card p-4">
+        <ConfigHealthBanner />
+        <div className="flex min-h-0 flex-1 overflow-hidden rounded-xl bg-card">
+          <Outlet />
+        </div>
       </main>
     </div>
   );

--- a/frontend/src/app/setting/components/config-health-banner.tsx
+++ b/frontend/src/app/setting/components/config-health-banner.tsx
@@ -1,0 +1,59 @@
+import { TriangleAlert } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { NavLink } from "react-router";
+import { getVisibleConfigHealthIssues, useConfigHealth } from "@/api/system";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { cn } from "@/lib/utils";
+
+export function ConfigHealthBanner() {
+  const { t } = useTranslation();
+  const { data: configHealth } = useConfigHealth();
+
+  const visibleIssues = getVisibleConfigHealthIssues(configHealth).slice(0, 3);
+  const hasError = visibleIssues.some((issue) => issue.level === "error");
+
+  if (visibleIssues.length === 0) {
+    return null;
+  }
+
+  const descriptionKey = configHealth?.primary_provider
+    ? "general.configHealth.descriptionWithProvider"
+    : "general.configHealth.description";
+
+  return (
+    <Alert
+      variant={hasError ? "destructive" : "default"}
+      className={cn(
+        "border",
+        !hasError &&
+          "border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/70 dark:bg-amber-950/30 dark:text-amber-100",
+      )}
+    >
+      <TriangleAlert className="size-4" />
+      <AlertTitle className="flex flex-wrap items-center gap-2">
+        {t("general.configHealth.title")}
+      </AlertTitle>
+      <AlertDescription>
+        <p>
+          {t(descriptionKey, {
+            provider: configHealth?.primary_provider,
+          })}{" "}
+          <NavLink
+            to="/setting"
+            className="font-medium underline underline-offset-4"
+          >
+            {t("general.configHealth.openModels")}
+          </NavLink>
+        </p>
+        <ul className="list-disc pl-5">
+          {visibleIssues.map((issue) => (
+            <li key={`${issue.level}:${issue.scope}:${issue.message}`}>
+              <span className="font-medium">{issue.scope}</span>:{" "}
+              {issue.message}
+            </li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -36,6 +36,12 @@
     "updates": {
       "title": "App Updates",
       "check": "Check for Update"
+    },
+    "configHealth": {
+      "title": "Configuration needs attention",
+      "description": "ValueCell found configuration issues that should be fixed before provider checks or runs fail.",
+      "descriptionWithProvider": "ValueCell found configuration issues for {{provider}} that should be fixed before provider checks or runs fail.",
+      "openModels": "Open Models settings"
     }
   },
   "auth": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -36,6 +36,12 @@
     "updates": {
       "title": "アプリアップデート",
       "check": "アップデートを確認"
+    },
+    "configHealth": {
+      "title": "設定の確認が必要です",
+      "description": "ValueCell で設定の問題が見つかりました。provider のチェックや実行が失敗する前に修正してください。",
+      "descriptionWithProvider": "{{provider}} の設定に問題があります。provider のチェックや実行が失敗する前に修正してください。",
+      "openModels": "モデル設定を開く"
     }
   },
   "auth": {

--- a/frontend/src/i18n/locales/zh_CN.json
+++ b/frontend/src/i18n/locales/zh_CN.json
@@ -36,6 +36,12 @@
     "updates": {
       "title": "应用更新",
       "check": "检查更新"
+    },
+    "configHealth": {
+      "title": "配置需要处理",
+      "description": "ValueCell 发现了配置问题，建议先修复再继续做 provider 检查或实际运行。",
+      "descriptionWithProvider": "ValueCell 发现 {{provider}} 的配置存在问题，建议先修复再继续做 provider 检查或实际运行。",
+      "openModels": "打开模型设置"
     }
   },
   "auth": {

--- a/frontend/src/i18n/locales/zh_TW.json
+++ b/frontend/src/i18n/locales/zh_TW.json
@@ -36,6 +36,12 @@
     "updates": {
       "title": "應用程式更新",
       "check": "檢查更新"
+    },
+    "configHealth": {
+      "title": "配置需要處理",
+      "description": "ValueCell 發現了配置問題，建議先修復再繼續做 provider 檢查或實際運行。",
+      "descriptionWithProvider": "ValueCell 發現 {{provider}} 的配置存在問題，建議先修復再繼續做 provider 檢查或實際運行。",
+      "openModels": "打開模型設定"
     }
   },
   "auth": {


### PR DESCRIPTION
## Summary\n- add a dedicated config-health query and filter helper for actionable issues\n- surface warning/error config-health state as a minimal banner in settings\n- add localized copy that points users back to Models settings for remediation\n\n## Testing\n- bun test ./src/api/system.test.ts\n- bun run typecheck\n- bunx @biomejs/biome@2.4.12 check ./src/api/system.ts ./src/api/system.test.ts ./src/app/setting/_layout.tsx ./src/app/setting/components/config-health-banner.tsx ./src/i18n/locales/en.json ./src/i18n/locales/zh_CN.json ./src/i18n/locales/zh_TW.json ./src/i18n/locales/ja.json\n\nRefs #44