### PR TITLE
docs: define config version domains

### DIFF
--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -77,6 +77,31 @@ The system will auto-detect available providers based on configured API keys.
 
 ## Configuration System Architecture
 
+## Schema / Version Domains
+
+ValueCell now treats configuration evolution as a small set of explicit domains instead of ad-hoc one-off fixes.
+
+| Domain | Owner | Schema key | Versioning mode | Current version | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `frontend.persist.settings` | frontend | `valuecell-settings` | explicit | `1` | Zustand persisted settings store. Bump the persist version when the on-disk shape changes. |
+| `frontend.persist.system` | frontend | `valuecell-system-store` | explicit | `1` | Zustand persisted auth/system store. Bump the persist version when the persisted snapshot contract changes. |
+| `backend.runtime.config-health` | backend | `system.config-health` | normalized-contract | n/a | Runtime summary contract exposed by `/api/v1/system/config-health`. Keep payload fields stable and normalize malformed data at the API boundary. |
+| `backend.config.provider` | backend | `providers/*.yaml` | normalized-contract | n/a | Provider YAML keeps legacy compatibility, but load-time normalization owns fields like `default_model_ref` and `recommended_models`. |
+| `backend.config.agent` | backend | `agents/*.yaml` | normalized-contract | n/a | Agent YAML evolves via loader merge rules and `env_overrides`, not a per-file schema version number. |
+
+### Naming Rules
+
+- **Domain IDs** use `<owner>.<surface>.<domain>` naming, for example `frontend.persist.settings`.
+- **Schema keys** should point at the real storage or config boundary (`valuecell-settings`, `providers/*.yaml`, `system.config-health`).
+- Use **explicit** versioning only when data is persisted across app restarts and migration order matters.
+- Use **normalized-contract** when the boundary is load-time normalized and backward compatibility is enforced by sanitizing/normalizing inputs instead of bumping a stored version field.
+
+### How to Extend the Map
+
+- New frontend persisted stores must get a new explicit domain entry before adding another standalone `*_VERSION` constant.
+- New backend config payloads should first choose whether they are an explicit persisted schema or a normalized contract.
+- If a boundary changes shape but keeps the same normalized contract, extend the normalizer/tests instead of inventing a fake version number.
+
 ### File Structure
 
 ```

--- a/frontend/src/store/persist-version-domains.ts
+++ b/frontend/src/store/persist-version-domains.ts
@@ -1,0 +1,21 @@
+export interface PersistVersionDomain {
+  domain: string;
+  storageKey: string;
+  schemaVersion: number;
+}
+
+export const PERSIST_VERSION_DOMAINS = {
+  settings: {
+    domain: "frontend.persist.settings",
+    storageKey: "valuecell-settings",
+    schemaVersion: 1,
+  },
+  system: {
+    domain: "frontend.persist.system",
+    storageKey: "valuecell-system-store",
+    schemaVersion: 1,
+  },
+} as const satisfies Record<string, PersistVersionDomain>;
+
+export const SETTINGS_PERSIST_VERSION_DOMAIN = PERSIST_VERSION_DOMAINS.settings;
+export const SYSTEM_PERSIST_VERSION_DOMAIN = PERSIST_VERSION_DOMAINS.system;

--- a/frontend/src/store/settings-store.migrate.ts
+++ b/frontend/src/store/settings-store.migrate.ts
@@ -1,7 +1,9 @@
+import { SETTINGS_PERSIST_VERSION_DOMAIN } from "./persist-version-domains";
 import type { LanguageCode, StockColorMode } from "./settings-store.types";
 
 export const DEFAULT_LANGUAGE = "en";
-export const SETTINGS_STORE_VERSION = 1;
+export const SETTINGS_STORE_VERSION =
+  SETTINGS_PERSIST_VERSION_DOMAIN.schemaVersion;
 export const DEFAULT_STOCK_COLOR_MODE: StockColorMode = "GREEN_UP_RED_DOWN";
 
 export const normalizeLanguageCode = (language: unknown): LanguageCode => {

--- a/frontend/src/store/settings-store.persist.test.ts
+++ b/frontend/src/store/settings-store.persist.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { SETTINGS_PERSIST_VERSION_DOMAIN } from "./persist-version-domains";
 import {
   SETTINGS_STORE_NAME,
   settingsStorePersistOptions,
@@ -7,7 +8,13 @@ import {
 describe("settingsStorePersistOptions", () => {
   test("wires schema versioned migration metadata", () => {
     expect(settingsStorePersistOptions.name).toBe(SETTINGS_STORE_NAME);
+    expect(settingsStorePersistOptions.name).toBe(
+      SETTINGS_PERSIST_VERSION_DOMAIN.storageKey,
+    );
     expect(settingsStorePersistOptions.version).toBe(1);
+    expect(settingsStorePersistOptions.version).toBe(
+      SETTINGS_PERSIST_VERSION_DOMAIN.schemaVersion,
+    );
     expect(typeof settingsStorePersistOptions.migrate).toBe("function");
   });
 

--- a/frontend/src/store/settings-store.persist.ts
+++ b/frontend/src/store/settings-store.persist.ts
@@ -1,4 +1,5 @@
 import type { PersistOptions } from "zustand/middleware";
+import { SETTINGS_PERSIST_VERSION_DOMAIN } from "./persist-version-domains";
 import {
   migrateSettingsPersistedState,
   SETTINGS_STORE_VERSION,
@@ -10,7 +11,7 @@ export interface SettingsStorePersistedState {
   language: LanguageCode;
 }
 
-export const SETTINGS_STORE_NAME = "valuecell-settings";
+export const SETTINGS_STORE_NAME = SETTINGS_PERSIST_VERSION_DOMAIN.storageKey;
 
 export const settingsStorePersistOptions: Pick<
   PersistOptions<SettingsStorePersistedState>,

--- a/frontend/src/store/system-store.persist.test.ts
+++ b/frontend/src/store/system-store.persist.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { SYSTEM_PERSIST_VERSION_DOMAIN } from "./persist-version-domains";
 import {
   INITIAL_SYSTEM_INFO,
   migrateSystemPersistedState,
@@ -10,7 +11,13 @@ import {
 describe("systemStorePersistOptions", () => {
   test("wires schema versioned migration metadata", () => {
     expect(systemStorePersistOptions.name).toBe(SYSTEM_STORE_NAME);
+    expect(systemStorePersistOptions.name).toBe(
+      SYSTEM_PERSIST_VERSION_DOMAIN.storageKey,
+    );
     expect(systemStorePersistOptions.version).toBe(SYSTEM_STORE_VERSION);
+    expect(systemStorePersistOptions.version).toBe(
+      SYSTEM_PERSIST_VERSION_DOMAIN.schemaVersion,
+    );
     expect(typeof systemStorePersistOptions.migrate).toBe("function");
   });
 

--- a/frontend/src/store/system-store.persist.ts
+++ b/frontend/src/store/system-store.persist.ts
@@ -1,8 +1,9 @@
 import type { PersistOptions } from "zustand/middleware";
 import type { SystemInfo } from "@/types/system";
+import { SYSTEM_PERSIST_VERSION_DOMAIN } from "./persist-version-domains";
 
-export const SYSTEM_STORE_NAME = "valuecell-system-store";
-export const SYSTEM_STORE_VERSION = 1;
+export const SYSTEM_STORE_NAME = SYSTEM_PERSIST_VERSION_DOMAIN.storageKey;
+export const SYSTEM_STORE_VERSION = SYSTEM_PERSIST_VERSION_DOMAIN.schemaVersion;
 
 export type SystemStorePersistedState = SystemInfo;
 

--- a/python/valuecell/config/tests/test_versioning.py
+++ b/python/valuecell/config/tests/test_versioning.py
@@ -1,0 +1,36 @@
+from valuecell.config.versioning import CONFIG_VERSION_DOMAINS
+
+
+def test_config_version_domains_cover_frontend_persist_stores() -> None:
+    settings = CONFIG_VERSION_DOMAINS["frontend.persist.settings"]
+    system = CONFIG_VERSION_DOMAINS["frontend.persist.system"]
+
+    assert settings.owner == "frontend"
+    assert settings.schema_key == "valuecell-settings"
+    assert settings.versioning_mode == "explicit"
+    assert settings.current_version == 1
+
+    assert system.owner == "frontend"
+    assert system.schema_key == "valuecell-system-store"
+    assert system.versioning_mode == "explicit"
+    assert system.current_version == 1
+
+
+def test_config_version_domains_capture_backend_normalized_contracts() -> None:
+    provider = CONFIG_VERSION_DOMAINS["backend.config.provider"]
+    agent = CONFIG_VERSION_DOMAINS["backend.config.agent"]
+    config_health = CONFIG_VERSION_DOMAINS["backend.runtime.config-health"]
+
+    assert provider.owner == "backend"
+    assert provider.versioning_mode == "normalized-contract"
+    assert provider.current_version is None
+    assert "default_model_ref" in provider.notes
+
+    assert agent.owner == "backend"
+    assert agent.versioning_mode == "normalized-contract"
+    assert agent.current_version is None
+    assert "env_overrides" in agent.notes
+
+    assert config_health.schema_key == "system.config-health"
+    assert config_health.versioning_mode == "normalized-contract"
+    assert config_health.current_version is None

--- a/python/valuecell/config/versioning.py
+++ b/python/valuecell/config/versioning.py
@@ -1,0 +1,60 @@
+"""Configuration schema/version domains for ValueCell."""
+
+from dataclasses import dataclass
+from typing import Dict, Literal
+
+
+@dataclass(frozen=True)
+class ConfigVersionDomain:
+    """Single configuration evolution domain."""
+
+    domain: str
+    owner: Literal["frontend", "backend"]
+    schema_key: str
+    versioning_mode: Literal["explicit", "normalized-contract"]
+    current_version: int | None
+    notes: str
+
+
+CONFIG_VERSION_DOMAINS: Dict[str, ConfigVersionDomain] = {
+    "frontend.persist.settings": ConfigVersionDomain(
+        domain="frontend.persist.settings",
+        owner="frontend",
+        schema_key="valuecell-settings",
+        versioning_mode="explicit",
+        current_version=1,
+        notes="Zustand persisted settings store; migrations are gated by persist version metadata.",
+    ),
+    "frontend.persist.system": ConfigVersionDomain(
+        domain="frontend.persist.system",
+        owner="frontend",
+        schema_key="valuecell-system-store",
+        versioning_mode="explicit",
+        current_version=1,
+        notes="Zustand persisted system/auth store; sanitizes malformed snapshots at load time.",
+    ),
+    "backend.runtime.config-health": ConfigVersionDomain(
+        domain="backend.runtime.config-health",
+        owner="backend",
+        schema_key="system.config-health",
+        versioning_mode="normalized-contract",
+        current_version=None,
+        notes="Runtime config health summary contract exposed via /api/v1/system/config-health.",
+    ),
+    "backend.config.provider": ConfigVersionDomain(
+        domain="backend.config.provider",
+        owner="backend",
+        schema_key="providers/*.yaml",
+        versioning_mode="normalized-contract",
+        current_version=None,
+        notes="Provider YAML config keeps legacy fields but normalizes default_model_ref and recommended_models on load.",
+    ),
+    "backend.config.agent": ConfigVersionDomain(
+        domain="backend.config.agent",
+        owner="backend",
+        schema_key="agents/*.yaml",
+        versioning_mode="normalized-contract",
+        current_version=None,
+        notes="Agent YAML config resolves via loader merge rules and env_overrides instead of explicit schema version fields.",
+    ),
+}


### PR DESCRIPTION
## Summary\n- add explicit frontend persist version-domain registry for settings and system stores\n- add backend config version-domain registry to document normalized-contract vs explicit version boundaries\n- extend the configuration guide with a schema/version domain map and extension rules\n\n## Testing\n- bun test ./src/store/settings-store.persist.test.ts ./src/store/system-store.persist.test.ts ./src/store/settings-store.test.ts\n- python/.venv/bin/pytest python/valuecell/config/tests/test_versioning.py python/valuecell/config/tests/test_config_health.py python/valuecell/config/tests/test_provider_config_preferences.py\n- bun run typecheck\n- bunx @biomejs/biome@2.4.12 check ./src/store/persist-version-domains.ts ./src/store/settings-store.migrate.ts ./src/store/settings-store.persist.ts ./src/store/settings-store.persist.test.ts ./src/store/system-store.persist.ts ./src/store/system-store.persist.test.ts\n\nRefs #45