### PR TITLE
feat: clarify shared provider model contract

### DIFF
--- a/frontend/src/api/setting.test.ts
+++ b/frontend/src/api/setting.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeProviderDetail } from "./setting";
+
+describe("normalizeProviderDetail", () => {
+  test("keeps provider-native and canonical model selection fields distinct", () => {
+    expect(
+      normalizeProviderDetail({
+        api_key: "sk-test",
+        api_key_url: "https://platform.openai.com/api-keys",
+        base_url: "https://api.openai.com/v1",
+        is_default: true,
+        default_model_id: "gpt-5",
+        default_model_ref: "openai/gpt-5.4",
+        recommended_model_refs: ["openai/gpt-5.4", null, 1, "openai/gpt-4.1"],
+        models: [
+          { model_id: "gpt-5", model_name: "GPT-5" },
+          { model_id: "gpt-4.1", model_name: null },
+        ],
+      }),
+    ).toEqual({
+      api_key: "sk-test",
+      api_key_url: "https://platform.openai.com/api-keys",
+      base_url: "https://api.openai.com/v1",
+      is_default: true,
+      default_model_id: "gpt-5",
+      default_model_ref: "openai/gpt-5.4",
+      recommended_model_refs: ["openai/gpt-5.4", "openai/gpt-4.1"],
+      models: [
+        { model_id: "gpt-5", model_name: "GPT-5" },
+        { model_id: "gpt-4.1", model_name: "" },
+      ],
+    });
+  });
+
+  test("falls back malformed payloads to safe shared-contract defaults", () => {
+    expect(
+      normalizeProviderDetail({
+        api_key: null,
+        api_key_url: 42,
+        base_url: undefined,
+        is_default: "yes",
+        default_model_id: ["gpt-5"],
+        default_model_ref: 123,
+        recommended_model_refs: "openai/gpt-5.4",
+        models: [null, { model_name: "Missing id" }],
+      }),
+    ).toEqual({
+      api_key: "",
+      api_key_url: "",
+      base_url: "",
+      is_default: false,
+      default_model_id: "",
+      default_model_ref: undefined,
+      recommended_model_refs: [],
+      models: [],
+    });
+  });
+});

--- a/frontend/src/api/setting.ts
+++ b/frontend/src/api/setting.ts
@@ -17,6 +17,42 @@ import type {
   ProviderModelInfo,
 } from "@/types/setting";
 
+export const normalizeProviderDetail = (value: unknown): ProviderDetail => {
+  const data = (value ?? {}) as Partial<ProviderDetail>;
+
+  return {
+    api_key: typeof data.api_key === "string" ? data.api_key : "",
+    api_key_url: typeof data.api_key_url === "string" ? data.api_key_url : "",
+    base_url: typeof data.base_url === "string" ? data.base_url : "",
+    is_default: data.is_default === true,
+    default_model_id:
+      typeof data.default_model_id === "string" ? data.default_model_id : "",
+    default_model_ref:
+      typeof data.default_model_ref === "string"
+        ? data.default_model_ref
+        : undefined,
+    recommended_model_refs: Array.isArray(data.recommended_model_refs)
+      ? data.recommended_model_refs.filter(
+          (modelRef): modelRef is string => typeof modelRef === "string",
+        )
+      : [],
+    models: Array.isArray(data.models)
+      ? data.models
+          .filter(
+            (model): model is ProviderModelInfo =>
+              typeof model === "object" &&
+              model !== null &&
+              typeof (model as { model_id?: unknown }).model_id === "string",
+          )
+          .map((model) => ({
+            model_id: model.model_id,
+            model_name:
+              typeof model.model_name === "string" ? model.model_name : "",
+          }))
+      : [],
+  };
+};
+
 export const useGetMemoryList = () => {
   return useQuery({
     queryKey: API_QUERY_KEYS.SETTING.memoryList,
@@ -59,7 +95,7 @@ export const useGetModelProviderDetail = (provider: string | undefined) => {
       apiClient.get<ApiResponse<ProviderDetail>>(
         `/models/providers/${provider}`,
       ),
-    select: (data) => data.data,
+    select: (data) => normalizeProviderDetail(data.data),
   });
 };
 
@@ -212,10 +248,13 @@ export const useGetSortedModelProviders = () => {
         apiClient.get<ApiResponse<ProviderDetail>>(
           `/models/providers/${p.provider}`,
         ),
-      select: (data: ApiResponse<ProviderDetail>) => ({
-        provider: p.provider,
-        hasApiKey: !!data.data?.api_key,
-      }),
+      select: (data: ApiResponse<ProviderDetail>) => {
+        const providerDetail = normalizeProviderDetail(data.data);
+        return {
+          provider: p.provider,
+          hasApiKey: !!providerDetail.api_key,
+        };
+      },
       staleTime: 5 * 60 * 1000,
     })),
   });

--- a/frontend/src/types/setting.ts
+++ b/frontend/src/types/setting.ts
@@ -17,7 +17,12 @@ export type ProviderDetail = {
   api_key_url: string;
   base_url: string;
   is_default: boolean;
+  // Provider-native default model id used by current settings mutations/UI.
   default_model_id: string;
+  // Canonical shared-contract field for cross-provider model selection.
+  default_model_ref?: string;
+  // Canonical recommended refs from backend provider config.
+  recommended_model_refs: string[];
   models: ProviderModelInfo[];
 };
 

--- a/python/valuecell/server/api/routers/models.py
+++ b/python/valuecell/server/api/routers/models.py
@@ -490,6 +490,8 @@ def create_models_router() -> APIRouter:
                 base_url=cfg.base_url,
                 is_default=(cfg.name == manager.primary_provider),
                 default_model_id=cfg.default_model,
+                default_model_ref=cfg.default_model_ref,
+                recommended_model_refs=cfg.recommended_models or [],
                 api_key_url=_api_key_url_for(cfg.name),
                 models=models_entries,
             )
@@ -786,6 +788,8 @@ def create_models_router() -> APIRouter:
                 base_url=cfg.base_url,
                 is_default=(cfg.name == manager.primary_provider),
                 default_model_id=cfg.default_model,
+                default_model_ref=cfg.default_model_ref,
+                recommended_model_refs=cfg.recommended_models or [],
                 models=models_items,
             )
             return SuccessResponse.create(
@@ -974,6 +978,8 @@ def create_models_router() -> APIRouter:
                 base_url=cfg.base_url,
                 is_default=(cfg.name == manager.primary_provider),
                 default_model_id=cfg.default_model,
+                default_model_ref=cfg.default_model_ref,
+                recommended_model_refs=cfg.recommended_models or [],
                 models=models_items,
             )
             return SuccessResponse.create(

--- a/python/valuecell/server/api/schemas/model.py
+++ b/python/valuecell/server/api/schemas/model.py
@@ -47,7 +47,26 @@ class ProviderDetailData(BaseModel):
     api_key: Optional[str] = Field(None, description="API key if available")
     base_url: Optional[str] = Field(None, description="API base URL")
     is_default: bool = Field(..., description="Whether this is the primary provider")
-    default_model_id: Optional[str] = Field(None, description="Default model id")
+    default_model_id: Optional[str] = Field(
+        None,
+        description=(
+            "Provider-native default model id used by the settings UI and "
+            "default-model mutation endpoints"
+        ),
+    )
+    default_model_ref: Optional[str] = Field(
+        None,
+        description=(
+            "Canonical default model ref when the provider config exposes a "
+            "shared cross-provider model-selection contract"
+        ),
+    )
+    recommended_model_refs: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Canonical recommended model refs for shared provider/model selection"
+        ),
+    )
     api_key_url: Optional[str] = Field(
         None, description="URL to obtain/apply for the provider's API key"
     )

--- a/python/valuecell/server/api/tests/test_models_catalog_api.py
+++ b/python/valuecell/server/api/tests/test_models_catalog_api.py
@@ -367,6 +367,41 @@ def test_import_catalog_from_scan_selected_model_ids_only(
     assert len(catalog_response.json()["data"]) == 1
 
 
+def test_provider_detail_exposes_shared_model_selection_contract_fields(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _prepare_config(tmp_path)
+    _write_provider_file(
+        tmp_path,
+        "minimax",
+        """
+connection:
+  base_url: https://api.minimax.io/v1
+  api_key_env: MINIMAX_API_KEY
+default_model: MiniMax-M2.7
+default_model_ref: minimax/MiniMax-M2.7
+recommended_models:
+  - minimax/MiniMax-M2.7
+  - minimax/MiniMax-M2.5
+models:
+  - id: MiniMax-M2.7
+    name: MiniMax M2.7
+""",
+    )
+    client = _build_client(tmp_path, monkeypatch)
+
+    detail_response = client.get("/api/v1/models/providers/minimax")
+    assert detail_response.status_code == 200
+    detail = detail_response.json()["data"]
+    assert detail["api_key_url"] == "https://platform.minimax.io/"
+    assert detail["default_model_id"] == "MiniMax-M2.7"
+    assert detail["default_model_ref"] == "minimax/MiniMax-M2.7"
+    assert detail["recommended_model_refs"] == [
+        "minimax/MiniMax-M2.7",
+        "minimax/MiniMax-M2.5",
+    ]
+
+
 def test_minimax_provider_detail_and_validate_missing_api_key(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -391,6 +426,8 @@ models:
     detail = detail_response.json()["data"]
     assert detail["api_key_url"] == "https://platform.minimax.io/"
     assert detail["default_model_id"] == "MiniMax-M2.7"
+    assert detail["default_model_ref"] is None
+    assert detail["recommended_model_refs"] == []
 
     validate_response = client.post(
         "/api/v1/models/validate",
@@ -430,6 +467,8 @@ models:
         == "https://www.minimaxi.com/platform/user-center/basic-information/interface-key"
     )
     assert detail["default_model_id"] == "MiniMax-M2.7"
+    assert detail["default_model_ref"] is None
+    assert detail["recommended_model_refs"] == []
 
     validate_response = client.post(
         "/api/v1/models/validate",


### PR DESCRIPTION
## Summary\n- extend provider detail API payloads with canonical shared-contract fields for model selection\n- keep legacy provider-native  behavior for current settings UI flows\n- add frontend normalization/tests so malformed provider detail payloads fail closed instead of drifting silently\n\n## Testing\n- bun test ./src/api/setting.test.ts\n- python/.venv/bin/pytest python/valuecell/server/api/tests/test_models_catalog_api.py -q\n- bun run typecheck\n- bunx @biomejs/biome@2.4.12 check ./src/api/setting.ts ./src/api/setting.test.ts ./src/types/setting.ts\n\nRefs #46