### PR TITLE
fix: scope task component status updates by task id

### DIFF
--- a/python/valuecell/core/conversation/item_store.py
+++ b/python/valuecell/core/conversation/item_store.py
@@ -66,6 +66,7 @@ class InMemoryItemStore(ItemStore):
         offset: int = 0,
         role: Optional[Role] = None,
         task_id: Optional[str] = None,
+        **kwargs,
     ) -> List[ConversationItem]:
         """Return items filtered by conversation/task/role in insertion order."""
         if conversation_id is not None:

--- a/python/valuecell/core/conversation/item_store.py
+++ b/python/valuecell/core/conversation/item_store.py
@@ -66,7 +66,6 @@ class InMemoryItemStore(ItemStore):
         offset: int = 0,
         role: Optional[Role] = None,
         task_id: Optional[str] = None,
-        **kwargs,
     ) -> List[ConversationItem]:
         """Return items filtered by conversation/task/role in insertion order."""
         if conversation_id is not None:

--- a/python/valuecell/core/conversation/item_store.py
+++ b/python/valuecell/core/conversation/item_store.py
@@ -28,6 +28,7 @@ class ItemStore(ABC):
         offset: int = 0,
         role: Optional[Role] = None,
         task_id: Optional[str] = None,
+        **kwargs,
     ) -> List[ConversationItem]: ...
 
     @abstractmethod

--- a/python/valuecell/core/conversation/item_store.py
+++ b/python/valuecell/core/conversation/item_store.py
@@ -28,7 +28,8 @@ class ItemStore(ABC):
         offset: int = 0,
         role: Optional[Role] = None,
         task_id: Optional[str] = None,
-    ) -> List[ConversationItem]: ...
+    ) -> List[ConversationItem]:
+        ...
 
     @abstractmethod
     async def get_latest_item(
@@ -67,6 +68,7 @@ class InMemoryItemStore(ItemStore):
         role: Optional[Role] = None,
         task_id: Optional[str] = None,
     ) -> List[ConversationItem]:
+        """Return items filtered by conversation/task/role in insertion order."""
         if conversation_id is not None:
             items = list(self._items.get(conversation_id, []))
         else:

--- a/python/valuecell/core/conversation/item_store.py
+++ b/python/valuecell/core/conversation/item_store.py
@@ -28,7 +28,6 @@ class ItemStore(ABC):
         offset: int = 0,
         role: Optional[Role] = None,
         task_id: Optional[str] = None,
-        **kwargs,
     ) -> List[ConversationItem]: ...
 
     @abstractmethod

--- a/python/valuecell/core/conversation/item_store.py
+++ b/python/valuecell/core/conversation/item_store.py
@@ -28,8 +28,7 @@ class ItemStore(ABC):
         offset: int = 0,
         role: Optional[Role] = None,
         task_id: Optional[str] = None,
-    ) -> List[ConversationItem]:
-        ...
+    ) -> List[ConversationItem]: ...
 
     @abstractmethod
     async def get_latest_item(

--- a/python/valuecell/core/conversation/item_store.py
+++ b/python/valuecell/core/conversation/item_store.py
@@ -27,7 +27,7 @@ class ItemStore(ABC):
         limit: Optional[int] = None,
         offset: int = 0,
         role: Optional[Role] = None,
-        **kwargs,
+        task_id: Optional[str] = None,
     ) -> List[ConversationItem]: ...
 
     @abstractmethod
@@ -65,7 +65,7 @@ class InMemoryItemStore(ItemStore):
         limit: Optional[int] = None,
         offset: int = 0,
         role: Optional[Role] = None,
-        **kwargs,
+        task_id: Optional[str] = None,
     ) -> List[ConversationItem]:
         if conversation_id is not None:
             items = list(self._items.get(conversation_id, []))
@@ -76,6 +76,8 @@ class InMemoryItemStore(ItemStore):
                 items.extend(conv_items)
         if role is not None:
             items = [m for m in items if m.role == role]
+        if task_id is not None:
+            items = [m for m in items if m.task_id == task_id]
         if offset:
             items = items[offset:]
         if limit is not None:
@@ -193,9 +195,9 @@ class SQLiteItemStore(ItemStore):
         role: Optional[Role] = None,
         event: Optional[ConversationItemEvent] = None,
         component_type: Optional[str] = None,
+        task_id: Optional[str] = None,
         limit: Optional[int] = None,
         offset: int = 0,
-        **kwargs,
     ) -> List[ConversationItem]:
         await self._ensure_initialized()
         params = []
@@ -212,6 +214,9 @@ class SQLiteItemStore(ItemStore):
         if component_type is not None:
             where_clauses.append("json_extract(payload, '$.component_type') = ?")
             params.append(component_type)
+        if task_id is not None:
+            where_clauses.append("task_id = ?")
+            params.append(task_id)
 
         where = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
 

--- a/python/valuecell/core/conversation/manager.py
+++ b/python/valuecell/core/conversation/manager.py
@@ -252,6 +252,9 @@ class ConversationManager:
         """
         items = await self.item_store.get_items(task_id=task_id)
         for item in items:
+            if item.task_id != task_id:
+                continue
+
             # Check if this is a scheduled_task_controller component
             if not item.payload:
                 continue

--- a/python/valuecell/core/conversation/tests/test_conv_manager.py
+++ b/python/valuecell/core/conversation/tests/test_conv_manager.py
@@ -2,16 +2,20 @@
 Unit tests for valuecell.core.conversation.manager module
 """
 
-from datetime import datetime
 import json
+from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from valuecell.core.conversation.manager import ConversationManager
 from valuecell.core.conversation.models import Conversation, ConversationStatus
-from valuecell.core.types import ConversationItem, Role, NotifyResponseEvent
-from valuecell.core.types import ComponentType
+from valuecell.core.types import (
+    ComponentType,
+    ConversationItem,
+    NotifyResponseEvent,
+    Role,
+)
 
 
 class TestConversationManager:
@@ -736,6 +740,51 @@ class TestConversationManager:
         await manager.update_task_component_status("task-2", "failed", "boom")
 
         manager.item_store.save_item.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_task_component_status_skips_items_from_other_tasks(self):
+        """Items from other tasks should be ignored even if store filtering regresses."""
+        manager = ConversationManager()
+
+        target_payload = {
+            "component_type": ComponentType.SCHEDULED_TASK_CONTROLLER,
+            "content": json.dumps({"task_id": "task-1", "task_title": "A"}),
+        }
+        other_payload = {
+            "component_type": ComponentType.SCHEDULED_TASK_CONTROLLER,
+            "content": json.dumps({"task_id": "task-2", "task_title": "B"}),
+        }
+        target_item = ConversationItem(
+            item_id="item-target",
+            role=Role.AGENT,
+            event=NotifyResponseEvent.MESSAGE,
+            conversation_id="conv-1",
+            payload=json.dumps(target_payload),
+            metadata="{}",
+            task_id="task-1",
+        )
+        other_item = ConversationItem(
+            item_id="item-other",
+            role=Role.AGENT,
+            event=NotifyResponseEvent.MESSAGE,
+            conversation_id="conv-2",
+            payload=json.dumps(other_payload),
+            metadata="{}",
+            task_id="task-2",
+        )
+
+        manager.item_store.get_items = AsyncMock(return_value=[target_item, other_item])
+        manager.item_store.save_item = AsyncMock()
+
+        await manager.update_task_component_status("task-1", "failed", "boom")
+
+        manager.item_store.save_item.assert_awaited_once()
+        saved_item = manager.item_store.save_item.call_args.args[0]
+        assert saved_item.item_id == "item-target"
+        parsed = json.loads(saved_item.payload)
+        inner = json.loads(parsed.get("content"))
+        assert inner.get("task_status") == "failed"
+        assert json.loads(other_item.payload)["content"] == other_payload["content"]
 
     @pytest.mark.asyncio
     async def test_update_task_component_status_skips_invalid_payload(self):

--- a/python/valuecell/core/conversation/tests/test_in_memory_item_store.py
+++ b/python/valuecell/core/conversation/tests/test_in_memory_item_store.py
@@ -5,7 +5,7 @@ Unit tests for valuecell.core.conversation.item_store module - InMemoryItemStore
 import pytest
 
 from valuecell.core.conversation.item_store import InMemoryItemStore
-from valuecell.core.types import ConversationItem, Role, NotifyResponseEvent
+from valuecell.core.types import ConversationItem, NotifyResponseEvent, Role
 
 
 class TestInMemoryItemStore:
@@ -203,6 +203,35 @@ class TestInMemoryItemStore:
         result = await store.get_items("conv-123", role=Role.AGENT)
         assert len(result) == 2
         assert result == [agent_item1, agent_item2]
+
+    @pytest.mark.asyncio
+    async def test_get_items_with_task_id_filter(self):
+        """Test getting items filtered by task_id."""
+        store = InMemoryItemStore()
+
+        task1_item = ConversationItem(
+            item_id="task1-item",
+            role=Role.AGENT,
+            event=NotifyResponseEvent.MESSAGE,
+            conversation_id="conv-123",
+            task_id="task-1",
+            payload="Task 1 item",
+        )
+        task2_item = ConversationItem(
+            item_id="task2-item",
+            role=Role.AGENT,
+            event=NotifyResponseEvent.MESSAGE,
+            conversation_id="conv-456",
+            task_id="task-2",
+            payload="Task 2 item",
+        )
+
+        await store.save_item(task1_item)
+        await store.save_item(task2_item)
+
+        result = await store.get_items(conversation_id=None, task_id="task-1")
+
+        assert result == [task1_item]
 
     @pytest.mark.asyncio
     async def test_get_items_empty_conversation(self):

--- a/python/valuecell/core/conversation/tests/test_sqlite_item_store.py
+++ b/python/valuecell/core/conversation/tests/test_sqlite_item_store.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 
 import pytest
+
 from valuecell.core.conversation.item_store import SQLiteItemStore
 from valuecell.core.types import ConversationItem, Role, SystemResponseEvent
 
@@ -188,6 +189,14 @@ async def test_sqlite_item_store_filters_and_pagination():
         # filter by component_type (json_extract on payload)
         cards = await store.get_items("s2", component_type="card")
         assert [i.item_id for i in cards] == ["a2"]
+
+        # filter by task_id
+        items[1].task_id = "task-2"
+        items[2].task_id = "task-3"
+        await store.save_item(items[1])
+        await store.save_item(items[2])
+        task2_items = await store.get_items("s2", task_id="task-2")
+        assert [i.item_id for i in task2_items] == ["a2"]
 
         # limit & offset: get first item only, then skip first
         first = await store.get_items("s2", limit=1)


### PR DESCRIPTION
## Summary
- add first-class `task_id` filtering support to conversation item stores
- guard `update_task_component_status()` against cross-task item updates even if store filtering regresses
- add regression coverage for multi-task manager updates and store-level `task_id` queries

## Validation
- `python/.venv/bin/pytest python/valuecell/core/conversation/tests/test_conv_manager.py python/valuecell/core/conversation/tests/test_in_memory_item_store.py python/valuecell/core/conversation/tests/test_sqlite_item_store.py`
- `uv run --directory python isort --check valuecell/core/conversation/item_store.py valuecell/core/conversation/manager.py valuecell/core/conversation/tests/test_conv_manager.py valuecell/core/conversation/tests/test_in_memory_item_store.py valuecell/core/conversation/tests/test_sqlite_item_store.py`
- `uv run --directory python ruff check valuecell/core/conversation/item_store.py valuecell/core/conversation/manager.py valuecell/core/conversation/tests/test_conv_manager.py valuecell/core/conversation/tests/test_in_memory_item_store.py valuecell/core/conversation/tests/test_sqlite_item_store.py`
- `uv run --directory python ruff format --check valuecell/core/conversation/item_store.py valuecell/core/conversation/manager.py valuecell/core/conversation/tests/test_conv_manager.py valuecell/core/conversation/tests/test_in_memory_item_store.py valuecell/core/conversation/tests/test_sqlite_item_store.py`

Closes #31