### PR TITLE
fix: propagate remote task cancellation

### DIFF
--- a/python/valuecell/core/event/router.py
+++ b/python/valuecell/core/event/router.py
@@ -24,6 +24,7 @@ class SideEffectKind(Enum):
     """
 
     FAIL_TASK = "fail_task"
+    CANCEL_TASK = "cancel_task"
 
 
 @dataclass
@@ -88,6 +89,16 @@ async def handle_status_update(
             responses=responses,
             done=True,
             side_effects=[SideEffect(kind=SideEffectKind.FAIL_TASK, reason=err_msg)],
+        )
+
+    if state == TaskState.canceled:
+        cancel_reason = get_message_text(event.status.message, "")
+        return RouteResult(
+            responses=responses,
+            done=True,
+            side_effects=[
+                SideEffect(kind=SideEffectKind.CANCEL_TASK, reason=cancel_reason)
+            ],
         )
 
     if not event.metadata:

--- a/python/valuecell/core/event/tests/test_response_router.py
+++ b/python/valuecell/core/event/tests/test_response_router.py
@@ -29,6 +29,7 @@ class TestSideEffectKind:
     def test_enum_values(self):
         """Test SideEffectKind enum values."""
         assert SideEffectKind.FAIL_TASK.value == "fail_task"
+        assert SideEffectKind.CANCEL_TASK.value == "cancel_task"
 
 
 class TestSideEffect:
@@ -211,6 +212,37 @@ class TestHandleStatusUpdate:
         assert result.side_effects[0].kind == SideEffectKind.FAIL_TASK
         # Should extract text from complex message
         assert "Complex error" in result.side_effects[0].reason
+
+    async def test_canceled_state(self):
+        """Test handling canceled task state."""
+        response_factory = MagicMock()
+        task = Task(
+            task_id="task-123",
+            conversation_id="conv-123",
+            name="Test Task",
+            query="Test query",
+            user_id="user-123",
+            agent_name="test-agent",
+        )
+        thread_id = "thread-123"
+        m = Message(
+            message_id="m1", role=Role.agent, parts=[TextPart(text="User cancelled")]
+        )
+        event = TaskStatusUpdateEvent(
+            context_id="ctx-123",
+            task_id="task-123",
+            final=True,
+            status=TaskStatus(state=TaskState.canceled, message=m),
+        )
+
+        result = await handle_status_update(response_factory, task, thread_id, event)
+
+        assert isinstance(result, RouteResult)
+        assert result.responses == []
+        assert result.done is True
+        assert len(result.side_effects) == 1
+        assert result.side_effects[0].kind == SideEffectKind.CANCEL_TASK
+        assert result.side_effects[0].reason == "User cancelled"
 
     async def test_no_metadata(self):
         """Test handling event with no metadata."""

--- a/python/valuecell/core/task/executor.py
+++ b/python/valuecell/core/task/executor.py
@@ -302,14 +302,22 @@ class TaskExecutor:
                     logger.info(f"Task `{task.title}` ({task_id}) is finished.")
                     break
 
-            await self._task_service.complete_task(task_id)
-            completed = self._event_service.factory.task_completed(
-                conversation_id=conversation_id,
-                thread_id=thread_id,
-                task_id=task_id,
-                agent_name=task.agent_name,
-            )
-            yield await self._event_service.emit(completed)
+            completed_ok = await self._task_service.complete_task(task_id)
+            if completed_ok:
+                completed = self._event_service.factory.task_completed(
+                    conversation_id=conversation_id,
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    agent_name=task.agent_name,
+                )
+                yield await self._event_service.emit(completed)
+            else:
+                current_task = await self._task_service.get_task(task_id)
+                logger.info(
+                    "Skipping task_completed emission for task {} with status {}",
+                    task_id,
+                    current_task.status if current_task else "unknown",
+                )
         except Exception as exc:
             await self._task_service.fail_task(task_id, str(exc))
             raise
@@ -422,6 +430,13 @@ class TaskExecutor:
                         await self._conversation_service.manager.update_task_component_status(
                             task_id=task.task_id,
                             status=TaskStatus.FAILED.value,
+                            error_reason=side_effect.reason,
+                        )
+                    if side_effect.kind == SideEffectKind.CANCEL_TASK:
+                        await self._task_service.cancel_task(task.task_id)
+                        await self._conversation_service.manager.update_task_component_status(
+                            task_id=task.task_id,
+                            status=TaskStatus.CANCELLED.value,
                             error_reason=side_effect.reason,
                         )
                 if route_result.done:

--- a/python/valuecell/core/task/tests/test_executor.py
+++ b/python/valuecell/core/task/tests/test_executor.py
@@ -3,10 +3,17 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from a2a.types import TaskState, TaskStatus, TaskStatusUpdateEvent
 
 from valuecell.core.event.factory import ResponseFactory
+from valuecell.core.event.router import RouteResult, SideEffect, SideEffectKind
 from valuecell.core.task.executor import ScheduledTaskResultAccumulator, TaskExecutor
-from valuecell.core.task.models import ScheduleConfig, Task, TaskPattern
+from valuecell.core.task.models import (
+    ScheduleConfig,
+    Task,
+    TaskPattern,
+    TaskStatus as CoreTaskStatus,
+)
 from valuecell.core.task.service import TaskService
 from valuecell.core.types import (
     CommonResponseEvent,
@@ -34,6 +41,7 @@ class StubEventService:
 class StubConversationService:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
+        self.manager = SimpleNamespace(update_task_component_status=AsyncMock())
 
     async def ensure_conversation(
         self,
@@ -51,6 +59,7 @@ def task_service() -> TaskService:
     svc.manager.start_task = AsyncMock(return_value=True)
     svc.manager.complete_task = AsyncMock(return_value=True)
     svc.manager.fail_task = AsyncMock(return_value=True)
+    svc.manager.cancel_task = AsyncMock(return_value=True)
     svc.manager.update_task = AsyncMock()
     return svc
 
@@ -381,3 +390,89 @@ async def test_execute_single_task_run_emits_result_component_when_no_events(
         == ComponentType.SCHEDULED_TASK_RESULT.value
         for r in emitted
     )
+
+
+@pytest.mark.asyncio
+async def test_execute_single_task_run_applies_cancel_side_effect(
+    task_service: TaskService,
+):
+    class FakeClient:
+        async def send_message(self, *args, **kwargs):
+            async def _events():
+                remote_task = SimpleNamespace(
+                    id="remote-1", status=SimpleNamespace(state=TaskState.submitted)
+                )
+                yield remote_task, None
+                yield remote_task, TaskStatusUpdateEvent(
+                    context_id="ctx-1",
+                    task_id="remote-1",
+                    final=True,
+                    status=TaskStatus(state=TaskState.canceled),
+                )
+
+            return _events()
+
+    class FakeConnections:
+        async def get_client(self, *_args, **_kwargs):
+            return FakeClient()
+
+    event_service = StubEventService()
+    event_service.route_task_status = AsyncMock(
+        return_value=RouteResult(
+            responses=[],
+            done=True,
+            side_effects=[SideEffect(kind=SideEffectKind.CANCEL_TASK, reason="stop")],
+        )
+    )
+    conversation_service = StubConversationService()
+    executor = TaskExecutor(
+        agent_connections=FakeConnections(),
+        task_service=task_service,
+        event_service=event_service,
+        conversation_service=conversation_service,
+    )
+    task = _make_task()
+
+    _ = [
+        resp
+        async for resp in executor._execute_single_task_run(
+            task, thread_id="thread", metadata={}
+        )
+    ]
+
+    task_service.manager.cancel_task.assert_awaited_once_with(task.task_id)
+    conversation_service.manager.update_task_component_status.assert_awaited_once_with(
+        task_id=task.task_id,
+        status=CoreTaskStatus.CANCELLED.value,
+        error_reason="stop",
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_task_skips_completed_event_when_complete_task_rejected(
+    monkeypatch: pytest.MonkeyPatch, task_service: TaskService
+):
+    event_service = StubEventService()
+    executor = TaskExecutor(
+        agent_connections=SimpleNamespace(),
+        task_service=task_service,
+        event_service=event_service,
+        conversation_service=StubConversationService(),
+    )
+
+    async def fake_single_run(task, thread_id, metadata):
+        if False:
+            yield  # pragma: no cover
+        return
+
+    monkeypatch.setattr(executor, "_execute_single_task_run", fake_single_run)
+    task_service.manager.complete_task = AsyncMock(return_value=False)
+    task_service.get_task = AsyncMock(
+        return_value=_make_task(status=CoreTaskStatus.CANCELLED)
+    )
+
+    task = _make_task()
+    emitted = [resp async for resp in executor.execute_task(task, "thread")]
+
+    assert not any(r.__class__.__name__ == "TaskCompletedResponse" for r in emitted)
+    task_service.manager.complete_task.assert_awaited_once_with(task.task_id)

--- a/python/valuecell/core/task/tests/test_executor.py
+++ b/python/valuecell/core/task/tests/test_executor.py
@@ -403,11 +403,14 @@ async def test_execute_single_task_run_applies_cancel_side_effect(
                     id="remote-1", status=SimpleNamespace(state=TaskState.submitted)
                 )
                 yield remote_task, None
-                yield remote_task, TaskStatusUpdateEvent(
-                    context_id="ctx-1",
-                    task_id="remote-1",
-                    final=True,
-                    status=TaskStatus(state=TaskState.canceled),
+                yield (
+                    remote_task,
+                    TaskStatusUpdateEvent(
+                        context_id="ctx-1",
+                        task_id="remote-1",
+                        final=True,
+                        status=TaskStatus(state=TaskState.canceled),
+                    ),
                 )
 
             return _events()


### PR DESCRIPTION
## Summary
This PR implements a focused first slice of issue #22 by wiring remote cancellation into the backend task lifecycle.

When a remote agent reports `TaskState.canceled`, the router now produces a dedicated cancel side effect, the executor persists the task as `cancelled`, updates persisted task component status accordingly, and avoids emitting a misleading `task_completed` event afterward.

## Why
Previously, remote cancellation was not modeled as a first-class lifecycle outcome in the backend execution path. That left a gap where a cancelled task could be locally under-modeled or even appear completed later, making lifecycle semantics harder to reason about.

## Scope
- add `CANCEL_TASK` side effect in task status routing
- map remote `TaskState.canceled` to local task cancellation
- update persisted conversation task component status to `cancelled`
- prevent `task_completed` emission when task completion is rejected because the task was already cancelled/finished
- add focused regression coverage

## Tests
```bash
cd python && .venv/bin/pytest valuecell/core/event/tests/test_response_router.py valuecell/core/task/tests/test_executor.py
```

Passed locally:
- `31 passed, 17 warnings in 2.99s`

## Issue
- closes #22 (first slice on remote cancellation semantics)

## Follow-ups
This PR intentionally does not yet cover the full lifecycle umbrella from #22, including:
- retry / resume / interruption state modeling
- partial output retention / labeling semantics
- frontend and API exposure of richer lifecycle states
