### PR TITLE
fix: preserve waiting-input task state

### DIFF
--- a/python/valuecell/core/event/router.py
+++ b/python/valuecell/core/event/router.py
@@ -9,10 +9,7 @@ from loguru import logger
 from valuecell.core.agent.responses import EventPredicates
 from valuecell.core.event.factory import ResponseFactory
 from valuecell.core.task.models import Task
-from valuecell.core.types import (
-    BaseResponse,
-    CommonResponseEvent,
-)
+from valuecell.core.types import BaseResponse, CommonResponseEvent
 
 
 class SideEffectKind(Enum):
@@ -25,6 +22,7 @@ class SideEffectKind(Enum):
 
     FAIL_TASK = "fail_task"
     CANCEL_TASK = "cancel_task"
+    WAIT_FOR_INPUT = "wait_for_input"
 
 
 @dataclass
@@ -74,7 +72,6 @@ async def handle_status_update(
         return RouteResult(responses)
 
     if state == TaskState.failed:
-        # Produce a task_failed response and request the task be marked failed
         err_msg = get_message_text(event.status.message)
         responses.append(
             response_factory.task_failed(
@@ -101,16 +98,24 @@ async def handle_status_update(
             ],
         )
 
+    if state == TaskState.input_required:
+        wait_reason = get_message_text(event.status.message, "")
+        return RouteResult(
+            responses=responses,
+            done=True,
+            side_effects=[
+                SideEffect(kind=SideEffectKind.WAIT_FOR_INPUT, reason=wait_reason)
+            ],
+        )
+
     if not event.metadata:
         return RouteResult(responses)
 
     response_event = event.metadata.get("response_event")
 
-    # Tool call events
     if state == TaskState.working and EventPredicates.is_tool_call(response_event):
         tool_call_id = event.metadata.get("tool_call_id", "unknown_tool_call_id")
         tool_name = event.metadata.get("tool_name", "unknown_tool_name")
-
         tool_result = None
         if "tool_result" in event.metadata and event.metadata["tool_result"]:
             tool_result = event.metadata.get("tool_result")
@@ -128,7 +133,6 @@ async def handle_status_update(
         )
         return RouteResult(responses)
 
-    # Reasoning messages
     content = get_message_text(event.status.message, "")
     if state == TaskState.working and EventPredicates.is_reasoning(response_event):
         responses.append(
@@ -143,7 +147,6 @@ async def handle_status_update(
         )
         return RouteResult(responses)
 
-    # component generator
     if (
         state == TaskState.working
         and response_event == CommonResponseEvent.COMPONENT_GENERATOR
@@ -163,7 +166,6 @@ async def handle_status_update(
         )
         return RouteResult(responses)
 
-    # general messages
     if state == TaskState.working and EventPredicates.is_message(response_event):
         responses.append(
             response_factory.message_response_general(

--- a/python/valuecell/core/event/tests/test_response_router.py
+++ b/python/valuecell/core/event/tests/test_response_router.py
@@ -30,6 +30,7 @@ class TestSideEffectKind:
         """Test SideEffectKind enum values."""
         assert SideEffectKind.FAIL_TASK.value == "fail_task"
         assert SideEffectKind.CANCEL_TASK.value == "cancel_task"
+        assert SideEffectKind.WAIT_FOR_INPUT.value == "wait_for_input"
 
 
 class TestSideEffect:

--- a/python/valuecell/core/event/tests/test_response_router.py
+++ b/python/valuecell/core/event/tests/test_response_router.py
@@ -245,6 +245,35 @@ class TestHandleStatusUpdate:
         assert result.side_effects[0].kind == SideEffectKind.CANCEL_TASK
         assert result.side_effects[0].reason == "User cancelled"
 
+    async def test_input_required_state_with_empty_message(self):
+        """Test input-required state keeps an empty message as empty reason."""
+        response_factory = MagicMock()
+        task = Task(
+            task_id="task-123",
+            conversation_id="conv-123",
+            name="Test Task",
+            query="Test query",
+            user_id="user-123",
+            agent_name="test-agent",
+        )
+        thread_id = "thread-123"
+        empty_message = Message(message_id="m2", role=Role.agent, parts=[])
+        event = TaskStatusUpdateEvent(
+            context_id="ctx-123",
+            task_id="task-123",
+            final=True,
+            status=TaskStatus(state=TaskState.input_required, message=empty_message),
+        )
+
+        result = await handle_status_update(response_factory, task, thread_id, event)
+
+        assert isinstance(result, RouteResult)
+        assert result.responses == []
+        assert result.done is True
+        assert len(result.side_effects) == 1
+        assert result.side_effects[0].kind == SideEffectKind.WAIT_FOR_INPUT
+        assert result.side_effects[0].reason == ""
+
     async def test_no_metadata(self):
         """Test handling event with no metadata."""
         response_factory = MagicMock()

--- a/python/valuecell/core/task/executor.py
+++ b/python/valuecell/core/task/executor.py
@@ -439,6 +439,16 @@ class TaskExecutor:
                             status=TaskStatus.CANCELLED.value,
                             error_reason=side_effect.reason,
                         )
+                    if side_effect.kind == SideEffectKind.WAIT_FOR_INPUT:
+                        await self._task_service.wait_for_input_task(task.task_id)
+                        await self._conversation_service.manager.update_task_component_status(
+                            task_id=task.task_id,
+                            status=TaskStatus.WAITING_INPUT.value,
+                            error_reason=side_effect.reason,
+                        )
+                        await self._conversation_service.require_user_input(
+                            task.conversation_id
+                        )
                 if route_result.done:
                     return
                 continue

--- a/python/valuecell/core/task/manager.py
+++ b/python/valuecell/core/task/manager.py
@@ -48,10 +48,21 @@ class TaskManager:
         """Complete task"""
         async with self._lock:
             task = await self._get_task(task_id)
-            if not task or task.is_finished():
+            if not task or task.status != TaskStatus.RUNNING:
                 return False
 
             task.complete()
+            await self._store.save_task(task)
+            return True
+
+    async def wait_for_input_task(self, task_id: str) -> bool:
+        """Mark task as waiting for additional user input."""
+        async with self._lock:
+            task = await self._get_task(task_id)
+            if not task or task.status != TaskStatus.RUNNING:
+                return False
+
+            task.wait_for_input()
             await self._store.save_task(task)
             return True
 

--- a/python/valuecell/core/task/models.py
+++ b/python/valuecell/core/task/models.py
@@ -109,6 +109,11 @@ class Task(BaseModel):
         self.completed_at = datetime.now()
         self.updated_at = datetime.now()
 
+    def wait_for_input(self) -> None:
+        """Pause the task pending additional user input."""
+        self.status = TaskStatus.WAITING_INPUT
+        self.updated_at = datetime.now()
+
     def fail(self, error_message: str) -> None:
         """Mark task as failed"""
         self.status = TaskStatus.FAILED

--- a/python/valuecell/core/task/service.py
+++ b/python/valuecell/core/task/service.py
@@ -36,6 +36,9 @@ class TaskService:
     async def complete_task(self, task_id: str) -> bool:
         return await self._manager.complete_task(task_id)
 
+    async def wait_for_input_task(self, task_id: str) -> bool:
+        return await self._manager.wait_for_input_task(task_id)
+
     async def fail_task(self, task_id: str, reason: str) -> bool:
         return await self._manager.fail_task(task_id, reason)
 

--- a/python/valuecell/core/task/tests/test_executor.py
+++ b/python/valuecell/core/task/tests/test_executor.py
@@ -58,6 +58,7 @@ def task_service() -> TaskService:
     svc = TaskService(manager=AsyncMock())
     svc.manager.start_task = AsyncMock(return_value=True)
     svc.manager.complete_task = AsyncMock(return_value=True)
+    svc.manager.wait_for_input_task = AsyncMock(return_value=True)
     svc.manager.fail_task = AsyncMock(return_value=True)
     svc.manager.cancel_task = AsyncMock(return_value=True)
     svc.manager.update_task = AsyncMock()
@@ -452,6 +453,74 @@ async def test_execute_single_task_run_applies_cancel_side_effect(
 
 
 @pytest.mark.asyncio
+async def test_execute_single_task_run_applies_wait_for_input_side_effect(
+    task_service: TaskService,
+):
+    class FakeClient:
+        async def send_message(self, *args, **kwargs):
+            async def _events():
+                remote_task = SimpleNamespace(
+                    id="remote-1", status=SimpleNamespace(state=TaskState.submitted)
+                )
+                yield remote_task, None
+                yield (
+                    remote_task,
+                    TaskStatusUpdateEvent(
+                        context_id="ctx-1",
+                        task_id="remote-1",
+                        final=True,
+                        status=TaskStatus(state=TaskState.input_required),
+                    ),
+                )
+
+            return _events()
+
+    class FakeConnections:
+        async def get_client(self, *_args, **_kwargs):
+            return FakeClient()
+
+    event_service = StubEventService()
+    event_service.route_task_status = AsyncMock(
+        return_value=RouteResult(
+            responses=[],
+            done=True,
+            side_effects=[
+                SideEffect(
+                    kind=SideEffectKind.WAIT_FOR_INPUT,
+                    reason="Need confirmation",
+                )
+            ],
+        )
+    )
+    conversation_service = StubConversationService()
+    conversation_service.require_user_input = AsyncMock()
+    executor = TaskExecutor(
+        agent_connections=FakeConnections(),
+        task_service=task_service,
+        event_service=event_service,
+        conversation_service=conversation_service,
+    )
+    task = _make_task()
+
+    _ = [
+        resp
+        async for resp in executor._execute_single_task_run(
+            task, thread_id="thread", metadata={}
+        )
+    ]
+
+    task_service.manager.wait_for_input_task.assert_awaited_once_with(task.task_id)
+    conversation_service.manager.update_task_component_status.assert_awaited_once_with(
+        task_id=task.task_id,
+        status=CoreTaskStatus.WAITING_INPUT.value,
+        error_reason="Need confirmation",
+    )
+    conversation_service.require_user_input.assert_awaited_once_with(
+        task.conversation_id
+    )
+
+
+@pytest.mark.asyncio
 async def test_execute_task_skips_completed_event_when_complete_task_rejected(
     monkeypatch: pytest.MonkeyPatch, task_service: TaskService
 ):
@@ -472,6 +541,36 @@ async def test_execute_task_skips_completed_event_when_complete_task_rejected(
     task_service.manager.complete_task = AsyncMock(return_value=False)
     task_service.get_task = AsyncMock(
         return_value=_make_task(status=CoreTaskStatus.CANCELLED)
+    )
+
+    task = _make_task()
+    emitted = [resp async for resp in executor.execute_task(task, "thread")]
+
+    assert not any(r.__class__.__name__ == "TaskCompletedResponse" for r in emitted)
+    task_service.manager.complete_task.assert_awaited_once_with(task.task_id)
+
+
+@pytest.mark.asyncio
+async def test_execute_task_skips_completed_event_for_waiting_input(
+    monkeypatch: pytest.MonkeyPatch, task_service: TaskService
+):
+    event_service = StubEventService()
+    executor = TaskExecutor(
+        agent_connections=SimpleNamespace(),
+        task_service=task_service,
+        event_service=event_service,
+        conversation_service=StubConversationService(),
+    )
+
+    async def fake_single_run(task, thread_id, metadata):
+        if False:
+            yield  # pragma: no cover
+        return
+
+    monkeypatch.setattr(executor, "_execute_single_task_run", fake_single_run)
+    task_service.manager.complete_task = AsyncMock(return_value=False)
+    task_service.get_task = AsyncMock(
+        return_value=_make_task(status=CoreTaskStatus.WAITING_INPUT)
     )
 
     task = _make_task()

--- a/python/valuecell/core/task/tests/test_manager.py
+++ b/python/valuecell/core/task/tests/test_manager.py
@@ -173,6 +173,49 @@ class TestTaskManager:
         assert result is False
 
     @pytest.mark.asyncio
+    async def test_complete_task_waiting_input(self):
+        """Test complete_task rejects waiting_input tasks."""
+        manager = TaskManager()
+        task = Task(
+            task_id="test-task-123",
+            query="Test query",
+            conversation_id="conv-123",
+            user_id="user-123",
+            agent_name="test-agent",
+            status=TaskStatus.WAITING_INPUT,
+        )
+        await manager._store.save_task(task)
+
+        result = await manager.complete_task("test-task-123")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_wait_for_input_task_success(self):
+        """Test wait_for_input_task with valid running task."""
+        manager = TaskManager()
+        task = Task(
+            task_id="test-task-123",
+            query="Test query",
+            conversation_id="conv-123",
+            user_id="user-123",
+            agent_name="test-agent",
+            status=TaskStatus.RUNNING,
+        )
+        await manager._store.save_task(task)
+
+        with patch("valuecell.core.task.models.datetime") as mock_datetime:
+            waiting_time = datetime(2023, 1, 1, 12, 5, 0)
+            mock_datetime.now.return_value = waiting_time
+
+            result = await manager.wait_for_input_task("test-task-123")
+
+            assert result is True
+            task = await manager._get_task("test-task-123")
+            assert task.status == TaskStatus.WAITING_INPUT
+            assert task.completed_at is None
+            assert task.updated_at == waiting_time
+
+    @pytest.mark.asyncio
     async def test_fail_task_success(self):
         """Test fail_task with valid running task."""
         manager = TaskManager()

--- a/python/valuecell/core/task/tests/test_manager.py
+++ b/python/valuecell/core/task/tests/test_manager.py
@@ -216,6 +216,26 @@ class TestTaskManager:
             assert task.updated_at == waiting_time
 
     @pytest.mark.asyncio
+    async def test_wait_for_input_task_rejects_non_running_task(self):
+        """Test wait_for_input_task rejects tasks that are not running."""
+        manager = TaskManager()
+        task = Task(
+            task_id="test-task-123",
+            query="Test query",
+            conversation_id="conv-123",
+            user_id="user-123",
+            agent_name="test-agent",
+            status=TaskStatus.PENDING,
+        )
+        await manager._store.save_task(task)
+
+        result = await manager.wait_for_input_task("test-task-123")
+
+        assert result is False
+        task = await manager._get_task("test-task-123")
+        assert task.status == TaskStatus.PENDING
+
+    @pytest.mark.asyncio
     async def test_fail_task_success(self):
         """Test fail_task with valid running task."""
         manager = TaskManager()

--- a/python/valuecell/core/task/tests/test_service_unit.py
+++ b/python/valuecell/core/task/tests/test_service_unit.py
@@ -11,6 +11,7 @@ def manager() -> AsyncMock:
     m.update_task = AsyncMock()
     m.start_task = AsyncMock(return_value=True)
     m.complete_task = AsyncMock(return_value=True)
+    m.wait_for_input_task = AsyncMock(return_value=True)
     m.fail_task = AsyncMock(return_value=True)
     m.cancel_task = AsyncMock(return_value=True)
     m.cancel_conversation_tasks = AsyncMock(return_value=2)
@@ -38,16 +39,18 @@ async def test_update_task(manager: AsyncMock):
 
 
 @pytest.mark.asyncio
-async def test_start_complete_fail_cancel(manager: AsyncMock):
+async def test_start_complete_wait_fail_cancel(manager: AsyncMock):
     service = TaskService(manager=manager)
 
     assert await service.start_task("task") is True
     assert await service.complete_task("task") is True
+    assert await service.wait_for_input_task("task") is True
     assert await service.fail_task("task", "reason") is True
     assert await service.cancel_task("task") is True
 
     manager.start_task.assert_awaited_once_with("task")
     manager.complete_task.assert_awaited_once_with("task")
+    manager.wait_for_input_task.assert_awaited_once_with("task")
     manager.fail_task.assert_awaited_once_with("task", "reason")
     manager.cancel_task.assert_awaited_once_with("task")
 


### PR DESCRIPTION
## Summary
This PR implements a second focused slice of issue #22 by preserving waiting-input semantics for interrupted task execution.

When a remote agent reports `TaskState.input_required`, the backend now treats that as a first-class interruption outcome instead of allowing the task to drift toward an incorrect completed state.

## What changed
- add `WAIT_FOR_INPUT` side effect in task status routing
- map remote `TaskState.input_required` to local `waiting_input`
- persist scheduled task component status as `waiting_input`
- mark the conversation as `require_user_input` when execution pauses for input
- tighten task completion so only `RUNNING -> COMPLETED` is allowed
- prevent `task_completed` emission for tasks that have transitioned to `waiting_input`
- add focused regression coverage for router, manager, service, and executor behavior

## Why
Issue #22 is about making cancellation / retry / resume / interruption semantics predictable. This slice covers the interruption half of that story: when execution pauses for more input, ValueCell should preserve that state explicitly instead of collapsing it into a misleading completion path.

## Tests
```bash
cd python && .venv/bin/pytest \
  valuecell/core/event/tests/test_response_router.py \
  valuecell/core/task/tests/test_manager.py \
  valuecell/core/task/tests/test_service_unit.py \
  valuecell/core/task/tests/test_executor.py
```

Passed locally:
- `57 passed, 17 warnings`

## Issue
- related to #22

## Follow-ups
This PR intentionally does not yet implement:
- true execution-stage resume after new user input is supplied
- retry semantics / retry state transitions
- partial output retention / merge rules across interruption and retry
- richer frontend/API exposure for resumable vs partial states
