### PR TITLE
fix: fall back on execution-stage continuation

### DIFF
--- a/python/valuecell/core/coordinate/orchestrator.py
+++ b/python/valuecell/core/coordinate/orchestrator.py
@@ -241,11 +241,23 @@ class AgentOrchestrator:
 
         # Validate execution context exists
         if conversation_id not in self._execution_contexts:
-            failure = self.event_service.factory.system_failed(
-                conversation_id,
-                "No execution context found for this conversation. The conversation may have expired.",
-            )
-            yield await self.event_service.emit(failure)
+            # Planning interruptions keep pending requests in PlanService. If a
+            # pending request still exists but context is missing, fail fast to
+            # avoid silently dropping a planner checkpoint.
+            if self.plan_service.has_pending_request(conversation_id):
+                failure = self.event_service.factory.system_failed(
+                    conversation_id,
+                    "No execution context found for this conversation. The conversation may have expired.",
+                )
+                yield await self.event_service.emit(failure)
+                return
+
+            # Execution-stage waiting_input currently does not persist a local
+            # ExecutionContext. Continue by re-activating the conversation and
+            # treating the user message as a fresh request.
+            await self.conversation_service.activate(conversation_id)
+            async for response in self._handle_new_request(user_input):
+                yield response
             return
 
         context = self._execution_contexts[conversation_id]

--- a/python/valuecell/core/coordinate/tests/test_orchestrator_context.py
+++ b/python/valuecell/core/coordinate/tests/test_orchestrator_context.py
@@ -11,7 +11,7 @@ from valuecell.core.coordinate.orchestrator import (
     ExecutionContext,
 )
 from valuecell.core.event.factory import ResponseFactory
-from valuecell.core.types import SystemResponseEvent
+from valuecell.core.types import SystemResponseEvent, UserInput, UserInputMetadata
 
 
 class DummyEventService:
@@ -217,3 +217,50 @@ async def test_cleanup_expired_contexts(orchestrator):
     assert "conv" in bundle.conversation_service.activated
     assert "conv" in bundle.plan_service.cleared
     assert "conv" not in orch._execution_contexts
+
+
+@pytest.mark.asyncio
+async def test_conversation_continuation_without_context_falls_back_to_new_request(
+    orchestrator,
+):
+    orch, bundle = orchestrator
+    user_input = UserInput(
+        query="yes, continue",
+        target_agent_name="agent",
+        meta=UserInputMetadata(conversation_id="conv", user_id="user"),
+    )
+
+    expected = bundle.event_service.factory.done("conv")
+
+    async def fake_new_request(_user_input):
+        yield expected
+
+    orch._handle_new_request = fake_new_request  # type: ignore[method-assign]
+
+    outputs = [
+        resp async for resp in orch._handle_conversation_continuation(user_input)
+    ]
+
+    assert outputs == [expected]
+    assert "conv" in bundle.conversation_service.activated
+
+
+@pytest.mark.asyncio
+async def test_conversation_continuation_without_context_still_fails_for_planning_pending(
+    orchestrator,
+):
+    orch, bundle = orchestrator
+    bundle.plan_service.pending = True
+
+    user_input = UserInput(
+        query="clarification",
+        target_agent_name="agent",
+        meta=UserInputMetadata(conversation_id="conv", user_id="user"),
+    )
+
+    outputs = [
+        resp async for resp in orch._handle_conversation_continuation(user_input)
+    ]
+
+    assert len(outputs) == 1
+    assert outputs[0].event == SystemResponseEvent.SYSTEM_FAILED


### PR DESCRIPTION
## Summary
This PR implements a focused third slice of issue #22 by improving execution-stage continuation semantics after a conversation has entered `require_user_input` due to waiting-input task execution.

Instead of immediately failing with missing execution-context errors in all such cases, the orchestrator now distinguishes between planning-stage interruptions and execution-stage waiting-input follow-up.

## What changed
- preserve existing strict failure behavior when the planner still has a pending user-input checkpoint but no execution context is available
- for continuation attempts without execution context and without planner pending state, reactivate the conversation and fall back to `_handle_new_request(...)`
- add focused orchestrator-context tests covering:
  - fallback to a fresh request path for execution-stage continuation without local context
  - retained failure behavior for planning-stage pending requests without context

## Why
Issue #22 is about making interruption / resume behavior predictable. After slice 2, tasks could enter `waiting_input`, but a user reply could still hit the old `No execution context found` / `Resuming execution stage is not yet supported` path. This PR narrows that gap by making execution-stage continuation degrade into a fresh request instead of a dead-end failure, while keeping planner checkpoint handling strict.

## Tests
```bash
cd python && .venv/bin/pytest \
  valuecell/core/coordinate/tests/test_orchestrator_context.py \
  valuecell/core/coordinate/tests/test_orchestrator.py
```

Passed locally:
- `16 passed, 18 warnings`

## Issue
- related to #22

## Follow-ups
This PR intentionally does not yet implement:
- true in-place remote task resume
- explicit retry state transitions
- partial output carry-forward / merge semantics across resumed execution
